### PR TITLE
fix TypeNotFoundException with nested Schemas

### DIFF
--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -245,17 +245,22 @@ class Schema
         throw new TypeNotFoundException(sprintf("Can't find the %s named {%s}#%s.", substr($getter, 3), $namespace, $name));
     }
 
+    /**
+     * @param string $namespace
+     * @param array $calling
+     * @return \GoetasWebservices\XML\XSDReader\Schema\Schema|null
+     */
     protected function findSchemaByNamespace($namespace, &$calling = array())
     {
         $calling[spl_object_hash($this)] = true;
         if ($this->getTargetNamespace() === $namespace) {
             return $this;
         } elseif ($this->hasChildren()) {
-            foreach($this->getSchemas() as $schema) {
+            foreach ($this->getSchemas() as $schema) {
                 if (isset($calling[spl_object_hash($schema)])) {
                     continue;
                 }
-                if($found = $schema->findSchemaByNamespace($namespace, $calling)) {
+                if ($found = $schema->findSchemaByNamespace($namespace, $calling)) {
                     return $found;
                 }
             }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace GoetasWebservices\XML\XSDReader\Tests;
 
+use GoetasWebservices\XML\XSDReader\Schema\Schema;
+
 class SchemaTest extends BaseTest
 {
     public function testBaseEmpty()
@@ -35,6 +37,32 @@ class SchemaTest extends BaseTest
 
         $this->setExpectedException('GoetasWebservices\XML\XSDReader\Schema\Exception\TypeNotFoundException');
         $schema->$find('foo');
+    }
+
+    public function testFindElementInNestedSchemas()
+    {
+        $schemaRoot = new Schema();
+        $schema = new Schema();
+
+        $schema->addSchema($this->reader->readString('
+            <xs:schema xmlns:tns="http://www.my-company-domain.com/" 
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+                    version="1.0"
+                    targetNamespace="http://www.my-company-domain.com/">
+                <xs:element name="getCatalog" type="tns:getCatalog" />
+                <xs:complexType name="getCatalog">
+                    <xs:sequence>
+                    <xs:element name="arg0" type="xs:string" minOccurs="0" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:schema>'));
+
+        $schemaRoot->addSchema($schema);
+
+        $this->assertInstanceOf(
+            'GoetasWebservices\XML\XSDReader\Schema\Element\ElementDef',
+            $schemaRoot->findElement('getCatalog', 'http://www.my-company-domain.com/')
+        );
     }
 
     public function testBase()


### PR DESCRIPTION
Hi,

I have been trying https://github.com/goetas-webservices/soap-client and in order to parse my WSDL was experiencing a TypeNotFoundException when \GoetasWebservices\XML\XSDReader\Schema\Schema::findSomething get's called looking up the first domain specific element. 

I am not sure why it happens but the root schema seems to be built up like this:

rootSchema
- childSchema_1
  - subchild_1.1 
  - subchild_1.2
- childSchema_2 
  - subchild_2.1
  - subchild_2.2 
...

where my targetNamespace resides somewhere at the second level child. I am unsure if this is sth.  specific of my xsd but could reproduce the issue with a test. The proposed refactoring of \GoetasWebservices\XML\XSDReader\Schema\Schema::findSomething has fixed this issue for me.

What do you think?

Regards,
Patrick