### PR TITLE
adding an editorconfig that seems to match the project style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.xsd]
+indent_style = tab
+insert_final_newline = false
+
+[.travis.yml]
+indent_size = 2
+
+[composer.json]
+indent_style = tab


### PR DESCRIPTION
`insert_final_newline = false` seems to be ignored by the editorconfig plugin for Atom, but other than that this seems to match what's on master.