### PR TITLE
Moved retrieval of node documentation to a separate class

### DIFF
--- a/src/Documentation/DocumentationReader.php
+++ b/src/Documentation/DocumentationReader.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GoetasWebservices\XML\XSDReader\Documentation;
+
+use DOMElement;
+
+interface DocumentationReader
+{
+    public function get(DOMElement $node);
+}

--- a/src/Documentation/StandardDocumentationReader.php
+++ b/src/Documentation/StandardDocumentationReader.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace GoetasWebservices\XML\XSDReader\Documentation;
+
+use DOMElement;
+
+class StandardDocumentationReader implements DocumentationReader
+{
+    public function get(DOMElement $node)
+    {
+        $doc = '';
+        foreach ($node->childNodes as $childNode) {
+            if ($childNode->localName == 'annotation') {
+                foreach ($childNode->childNodes as $subChildNode) {
+                    if ($subChildNode->localName == 'documentation') {
+                        $doc .= ($subChildNode->nodeValue);
+                    }
+                }
+            }
+        }
+        $doc = preg_replace('/[\t ]+/', ' ', $doc);
+
+        return trim($doc);
+    }
+}

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -111,7 +111,7 @@ class Schema
         $this->elements[$element->getName()] = $element;
     }
 
-    public function addSchema(Schema $schema, $namespace = null)
+    public function addSchema(self $schema, $namespace = null)
     {
         if ($namespace !== null && $schema->getTargetNamespace() !== $namespace) {
             throw new SchemaException(sprintf("The target namespace ('%s') for schema, does not match the declared namespace '%s'", $schema->getTargetNamespace(), $namespace));

--- a/src/Schema/Type/SimpleType.php
+++ b/src/Schema/Type/SimpleType.php
@@ -36,7 +36,7 @@ class SimpleType extends Type
         return $this;
     }
 
-    public function addUnion(SimpleType $type)
+    public function addUnion(self $type)
     {
         $this->unions[] = $type;
 
@@ -56,7 +56,7 @@ class SimpleType extends Type
         return $this->list;
     }
 
-    public function setList(SimpleType $list)
+    public function setList(self $list)
     {
         $this->list = $list;
 

--- a/tests/Documentation/StandardDocumentationReaderTest.php
+++ b/tests/Documentation/StandardDocumentationReaderTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace GoetasWebservices\XML\XSDReader\Tests\Documentation;
+
+use GoetasWebservices\XML\XSDReader\Documentation\StandardDocumentationReader;
+
+class StandardDocumentationReaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var StandardDocumentationReader
+     */
+    private $reader;
+
+    public function setUp()
+    {
+        $this->reader = new StandardDocumentationReader();
+    }
+
+    public function testItReturnsAString()
+    {
+        $element = $this->getSampleElement('Some sample text');
+
+        $result = $this->reader->get($element);
+
+        $this->assertInternalType('string', $result);
+    }
+
+    public function testItReturnsTheTrimmedAnnotationDocumentationText()
+    {
+        $text = 'Some sample text';
+        $element = $this->getSampleElement($text);
+
+        $result = $this->reader->get($element);
+
+        $this->assertSame($text, $result);
+    }
+
+    public function testItReplacesTabsToSpacesInDocumentationText()
+    {
+        $text = "Some\t\tsample text";
+        $element = $this->getSampleElement($text);
+
+        $result = $this->reader->get($element);
+
+        $this->assertSame('Some sample text', $result);
+    }
+
+    public function testItReplacesMultipleSpacesToSingleSpacesInDocumentationText()
+    {
+        $text = 'Some    sample text';
+        $element = $this->getSampleElement($text);
+
+        $result = $this->reader->get($element);
+
+        $this->assertSame('Some sample text', $result);
+    }
+
+    public function testItReturnsAnEmptyStringWhenDocumentationIsNotFoundInElement()
+    {
+        $element = $this->getSampleElementWithoutDocumentation();
+
+        $result = $this->reader->get($element);
+
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * @return \DOMElement
+     */
+    private function getSampleElement($text)
+    {
+        $xml = <<<XML
+<xs:schema targetNamespace="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:simpleType name="fooBar">
+    <xs:annotation>
+        <xs:documentation>
+            $text
+        </xs:documentation>
+    </xs:annotation>
+</xs:simpleType>
+</xs:schema>
+XML;
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($xml);
+        $element = $doc->getElementsByTagName('simpleType');
+
+        return $element->item(0);
+    }
+
+    private function getSampleElementWithoutDocumentation()
+    {
+        $xml = <<<XML
+<xs:schema targetNamespace="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:simpleType name="fooBar">
+    <xs:annotation>
+    </xs:annotation>
+</xs:simpleType>
+</xs:schema>
+XML;
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($xml);
+        $element = $doc->getElementsByTagName('simpleType');
+
+        return $element->item(0);
+    }
+}

--- a/tests/ElementsTest.php
+++ b/tests/ElementsTest.php
@@ -2,6 +2,8 @@
 
 namespace GoetasWebservices\XML\XSDReader\Tests;
 
+use GoetasWebservices\XML\XSDReader\Schema\Element\Element;
+
 class ElementsTest extends BaseTest
 {
     public function testBase()
@@ -79,5 +81,48 @@ class ElementsTest extends BaseTest
         $this->assertInstanceOf('GoetasWebservices\XML\XSDReader\Schema\Type\SimpleType', $base3);
         $this->assertEquals('http://www.w3.org/2001/XMLSchema', $base3->getSchema()->getTargetNamespace());
         $this->assertEquals('string', $base3->getName());
+    }
+
+    public function testElementSimpleTypeDocs()
+    {
+        $schema = $this->reader->readString(
+            '
+            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                 <xs:element name="myElementType" id="myElementType">
+                    <xs:simpleType>
+                        <xs:annotation>
+                            <xs:documentation>Element type description</xs:documentation>
+                        </xs:annotation>
+                    </xs:simpleType>
+                 </xs:element>
+            </xs:schema>');
+
+        $myElement = $schema->findElement('myElementType', 'http://www.example.com');
+        $this->assertSame(
+            'Element type description',
+            $myElement->getType()->getDoc()
+        );
+    }
+
+    public function testSequenceElementDocs()
+    {
+        $schema = $this->reader->readString(
+            '
+            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                <xs:group name="myGroup">
+                    <xs:sequence>
+                        <xs:element name="alone" type="xs:string">
+                            <xs:annotation>
+                                <xs:documentation>Alone description</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:group>
+            </xs:schema>');
+
+        $myGroup = $schema->findGroup('myGroup', 'http://www.example.com');
+        /** @var Element $aloneElement */
+        $aloneElement = $myGroup->getElements()[0];
+        $this->assertSame('Alone description', $aloneElement->getDoc());
     }
 }


### PR DESCRIPTION
The documentation belonging to a node is now read and returned by a separate documentation reader. This reader is injected into the `SchemaReader`. This allows us to implement our
own documentation readers for xsd definitions which use a specific data structure within `<documentation/>` tags.

To make sure this PR does not introduce a BC break, the `SchemaReader` will use the `StandardDocumentationReader` if no documentation reader is provided. The `StandardDocumentationReader` uses the exact same strategy as previously defined in `SchemaReader#getDocumentation()`. It should be noted, however, that it will break `goetas-webservices/xsd2php`, because it currently has a bug in the [services configuration](https://github.com/goetas-webservices/xsd2php/blob/cbc858ac4fb0bd5a4f1515893debac871122897d/src/Resources/config/services.xml#L11) of the schema reader. I've submitted a PR to fix this: goetas-webservices/xsd2php#45