### PR TITLE
Allow to specify schema location by namespace

### DIFF
--- a/src/SchemaReader.php
+++ b/src/SchemaReader.php
@@ -120,8 +120,9 @@ class SchemaReader
 
     /**
      * Override remote location with a local file.
-     * @param string $remote remote schema URL.
-     * @param string $local local file path.
+     *
+     * @param string $remote remote schema URL
+     * @param string $local  local file path
      */
     public function addKnownSchemaLocation(string $remote, string $local): void
     {
@@ -131,8 +132,9 @@ class SchemaReader
     /**
      * Specify schema location by namespace.
      * This can be used for schemas which import namespaces but do not specify schemaLocation attributes.
-     * @param string $remote remote schema URL.
-     * @param string $local local file path.
+     *
+     * @param string $remote remote schema URL
+     * @param string $local  local file path
      */
     public function addKnownNamespaceSchemaLocation(string $remote, string $local): void
     {

--- a/tests/ImportTest.php
+++ b/tests/ImportTest.php
@@ -72,6 +72,14 @@ class ImportTest extends BaseTest
         $this->assertInstanceOf(Schema::class, $schema);
     }
 
+    public function testKnownNamespaceLocationImport()
+    {
+        $this->reader->addKnownNamespaceSchemaLocation('urn:example:profile-1.1', __DIR__.'/schema/profile-1.1.xsd');
+
+        $schema = $this->reader->readFile(__DIR__.'/schema/transaction-1.0.xsd');
+        $this->assertInstanceOf(Schema::class, $schema);
+    }
+
     public function testBaseNode()
     {
         $dom = new \DOMDocument();

--- a/tests/schema/profile-1.1.xsd
+++ b/tests/schema/profile-1.1.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns="urn:example:profile-1.1"
+    xmlns:vct="urn:example:transaction-1.0"
+    targetNamespace="urn:example:profile-1.1">
+    
+  <xsd:import namespace="urn:example:transaction-1.0"
+    schemaLocation="transaction-1.0.xsd" />
+
+  <xsd:element name="GetProfileRequest" type="vct:RequestType">
+    <xsd:annotation>
+      <xsd:documentation>Example</xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+
+  <xsd:simpleType name="TransactionType">
+    <xsd:annotation>
+      <xsd:documentation>Liste der Transaktionen.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:normalizedString">
+      <xsd:enumeration value="Order">
+    <xsd:annotation>
+      <xsd:documentation>Order</xsd:documentation>
+    </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="OrderInOnlineShop">
+    <xsd:annotation>
+      <xsd:documentation>OrderInOnlineShop</xsd:documentation>
+    </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="TextSearch">
+    <xsd:annotation>
+      <xsd:documentation>Volltextsuche</xsd:documentation>
+    </xsd:annotation>
+      </xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/tests/schema/transaction-1.0.xsd
+++ b/tests/schema/transaction-1.0.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="urn:example:transaction-1.0"
+  xmlns:vcp="urn:example:profile-1.1"
+  targetNamespace="urn:example:transaction-1.0">
+
+  <xsd:import namespace="urn:example:profile-1.1"/><!-- this line does no specify schemaLocation -->
+
+  <xsd:complexType name="TransactionStatusType">
+    <xsd:sequence>
+      <xsd:element name="TransactionId" type="xsd:normalizedString" />
+      <xsd:element name="Transaction" type="vcp:TransactionType" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+  <xsd:complexType name="RequestType">
+    <xsd:sequence>
+      <xsd:element name="TransactionID" type="xsd:normalizedString" minOccurs="0" maxOccurs="1" />
+    </xsd:sequence>
+  </xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
currently there is the possiblity to call `addKnownSchemaLocation()`
which will override the URL for a schema to load.

this adds a new method `addKnownNamespaceSchemaLocation()` which adds a
schema location by namespace. This is used when no namespace is
specified in `xsd:import`.