### PR TITLE
add support for fixed attribute for elements

### DIFF
--- a/src/Schema/Element/AbstractElementSingle.php
+++ b/src/Schema/Element/AbstractElementSingle.php
@@ -36,6 +36,11 @@ class AbstractElementSingle extends Item implements ElementSingle
     /**
      * @var string|null
      */
+    protected $fixed;
+
+    /**
+     * @var string|null
+     */
     protected $default = null;
 
     public function isQualified(): bool
@@ -86,6 +91,16 @@ class AbstractElementSingle extends Item implements ElementSingle
     public function setMax(int $max): void
     {
         $this->max = $max;
+    }
+
+    public function getFixed(): ?string
+    {
+        return $this->fixed;
+    }
+
+    public function setFixed(string $fixed): void
+    {
+        $this->fixed = $fixed;
     }
 
     public function getDefault(): ?string

--- a/src/Schema/Element/ElementSingle.php
+++ b/src/Schema/Element/ElementSingle.php
@@ -6,7 +6,7 @@ namespace GoetasWebservices\XML\XSDReader\Schema\Element;
 
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 
-interface ElementSingle extends ElementItem, InterfaceSetMinMax, InterfaceSetDefault
+interface ElementSingle extends ElementItem, InterfaceSetMinMax, InterfaceSetFixed, InterfaceSetDefault
 {
     public function getType(): ?Type;
 

--- a/src/Schema/Element/InterfaceSetFixed.php
+++ b/src/Schema/Element/InterfaceSetFixed.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GoetasWebservices\XML\XSDReader\Schema\Element;
+
+interface InterfaceSetFixed
+{
+    public function getFixed(): ?string;
+
+    public function setFixed(string $fixed): void;
+}

--- a/src/SchemaReader.php
+++ b/src/SchemaReader.php
@@ -24,6 +24,7 @@ use GoetasWebservices\XML\XSDReader\Schema\Element\ElementRef;
 use GoetasWebservices\XML\XSDReader\Schema\Element\Group;
 use GoetasWebservices\XML\XSDReader\Schema\Element\GroupRef;
 use GoetasWebservices\XML\XSDReader\Schema\Element\InterfaceSetDefault;
+use GoetasWebservices\XML\XSDReader\Schema\Element\InterfaceSetFixed;
 use GoetasWebservices\XML\XSDReader\Schema\Element\InterfaceSetMinMax;
 use GoetasWebservices\XML\XSDReader\Schema\Exception\TypeNotFoundException;
 use GoetasWebservices\XML\XSDReader\Schema\Inheritance\Base;
@@ -328,6 +329,13 @@ class SchemaReader
             if ($ref->getMin() > $ref->getMax() && $ref->getMax() !== -1) {
                 $ref->setMax($ref->getMin());
             }
+        }
+    }
+
+    private static function maybeSetFixed(InterfaceSetFixed $ref, DOMElement $node): void
+    {
+        if ($node->hasAttribute('fixed')) {
+            $ref->setFixed($node->getAttribute('fixed'));
         }
     }
 
@@ -1385,6 +1393,7 @@ class SchemaReader
 
         self::maybeSetMax($element, $node);
         self::maybeSetMin($element, $node);
+        self::maybeSetFixed($element, $node);
         self::maybeSetDefault($element, $node);
 
         $xp = new \DOMXPath($node->ownerDocument);


### PR DESCRIPTION
This PR ensures that `fixed` attributes are read for elements as well.

Example:

`<xs:element name="fname" type="xs:string" fixed="Benjamin"/>`
