### PR TITLE
Fixes fatal error

### DIFF
--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1676539446">
-  <project timestamp="1676539446">
+<coverage generated="1680261076">
+  <project timestamp="1680261076">
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Documentation/DocumentationReader.php">
       <metrics loc="11" ncloc="11" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
     </file>

--- a/src/Schema/Type/SimpleType.php
+++ b/src/Schema/Type/SimpleType.php
@@ -11,7 +11,7 @@ class SimpleType extends Type
      */
     protected array $unions = [];
 
-    protected ?SimpleType $list;
+    protected ?SimpleType $list = null;
 
     public function addUnion(self $type): void
     {


### PR DESCRIPTION
Whilst parsing information from a simple type from my xsd schema, I'm getting:

> Fatal error: Uncaught Error: Typed property GoetasWebservices\XML\XSDReader\Schema\Type\SimpleType::$list must not be accessed before initialization in /vendor/goetas-webservices/xsd-reader/src/Schema/Type/SimpleType.php:32

This PR adds the default value of `null`, which solves the issue.
