### PR TITLE
fix missing sequence within choice

### DIFF
--- a/src/Schema/Element/MinMaxTrait.php
+++ b/src/Schema/Element/MinMaxTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GoetasWebservices\XML\XSDReader\Schema\Element;
+
+trait MinMaxTrait
+{
+    protected int $min = 1;
+
+    protected int $max = 1;
+
+    public function getMin(): int
+    {
+        return $this->min;
+    }
+
+    public function setMin(int $min): void
+    {
+        $this->min = $min;
+    }
+
+    public function getMax(): int
+    {
+        return $this->max;
+    }
+
+    public function setMax(int $max): void
+    {
+        $this->max = $max;
+    }
+}

--- a/src/Schema/Element/Sequence.php
+++ b/src/Schema/Element/Sequence.php
@@ -6,7 +6,7 @@ namespace GoetasWebservices\XML\XSDReader\Schema\Element;
 
 use GoetasWebservices\XML\XSDReader\Schema\AbstractNamedGroupItem;
 
-class Choice extends AbstractNamedGroupItem implements ElementItem, ElementContainer, InterfaceSetMinMax
+class Sequence extends AbstractNamedGroupItem implements ElementItem, ElementContainer, InterfaceSetMinMax
 {
     use ElementContainerTrait;
     use MinMaxTrait;

--- a/src/SchemaReader.php
+++ b/src/SchemaReader.php
@@ -1407,13 +1407,6 @@ class SchemaReader
         self::maybeSetDefault($element, $node);
         self::maybeSetAbstract($element, $node);
 
-        $xp = new \DOMXPath($node->ownerDocument);
-        $xp->registerNamespace('xs', self::XSD_NS);
-
-        if ($xp->query('ancestor::xs:choice', $node)->length) {
-            $element->setMin(0);
-        }
-
         if ($node->hasAttribute('nillable')) {
             $element->setNil('true' === $node->getAttribute('nillable'));
         }

--- a/src/SchemaReader.php
+++ b/src/SchemaReader.php
@@ -388,8 +388,8 @@ class SchemaReader
                 : null;
         $min =
             (
-                null === $min &&
-                !$node->hasAttribute('minOccurs')
+                null === $min
+                && !$node->hasAttribute('minOccurs')
             )
                 ? null
                 : (int) max((int) $min, $node->getAttribute('minOccurs'));
@@ -1080,8 +1080,8 @@ class SchemaReader
             $node,
             function (\DOMElement $node, \DOMElement $childNode) use ($element, &$skip): void {
                 if (
-                    !$skip &&
-                    in_array(
+                    !$skip
+                    && in_array(
                         $childNode->localName,
                         [
                             'complexType',

--- a/src/SchemaReader.php
+++ b/src/SchemaReader.php
@@ -1407,6 +1407,13 @@ class SchemaReader
         self::maybeSetDefault($element, $node);
         self::maybeSetAbstract($element, $node);
 
+        $xp = new \DOMXPath($node->ownerDocument);
+        $xp->registerNamespace('xs', self::XSD_NS);
+
+        if ($xp->query('ancestor::xs:choice', $node)->length) {
+            $element->setMin(0);
+        }
+
         if ($node->hasAttribute('nillable')) {
             $element->setNil('true' === $node->getAttribute('nillable'));
         }


### PR DESCRIPTION
Usually we can omit `all` and `sequence` elements and just process the contained elements. But if the current parent container is a choice, we need to persist the structural information to avoid that the inner elements get merged with each other. See the new test case for an example.