### PR TITLE
Fix issue with intepreting unbounded sequences as having a max limit of 2

### DIFF
--- a/src/SchemaReader.php
+++ b/src/SchemaReader.php
@@ -381,9 +381,9 @@ class SchemaReader
         $max =
             (
                 (is_int($max) && (bool) $max) ||
-                1 < $node->getAttribute('maxOccurs')
+                0 < $node->getAttribute('maxOccurs')
             ) && ('unbounded' !== $node->getAttribute('maxOccurs'))
-                ? 2
+                ? (int) min((int) $max, $node->getAttribute('maxOccurs'))
                 : null;
         $min =
             (

--- a/src/SchemaReader.php
+++ b/src/SchemaReader.php
@@ -380,10 +380,9 @@ class SchemaReader
     {
         $max =
             (
-                (is_int($max) && (bool) $max)
-                || 'unbounded' === $node->getAttribute('maxOccurs')
-                || 1 < $node->getAttribute('maxOccurs')
-            )
+                (is_int($max) && (bool) $max) ||
+                1 < $node->getAttribute('maxOccurs')
+            ) && ('unbounded' !== $node->getAttribute('maxOccurs'))
                 ? 2
                 : null;
         $min =

--- a/src/SchemaReader.php
+++ b/src/SchemaReader.php
@@ -378,13 +378,8 @@ class SchemaReader
 
     private function loadSequence(ElementContainer $elementContainer, \DOMElement $node, ?int $max = null, ?int $min = null): void
     {
-        $max =
-            (
-                (is_int($max) && (bool) $max) ||
-                0 < $node->getAttribute('maxOccurs')
-            ) && ('unbounded' !== $node->getAttribute('maxOccurs'))
-                ? (int) min((int) $max, $node->getAttribute('maxOccurs'))
-                : null;
+        $max = $this->loadMaxFromNode($node, $max);
+
         $min =
             (
                 null === $min
@@ -405,6 +400,29 @@ class SchemaReader
                 );
             }
         );
+    }
+
+    private function loadMaxFromNode(\DOMElement $node, ?int $max): ?int 
+    {
+        $maxOccurs = $node->getAttribute('maxOccurs');
+
+        if ('unbounded' === $maxOccurs && null === $max) {
+            return null;
+        }
+
+        if (is_numeric($maxOccurs)) {
+            $maxOccurs = intval($maxOccurs);
+
+            if (null !== $max) {
+                return min($max, $maxOccurs);
+            }
+
+            if (0 < $maxOccurs) {
+                return $maxOccurs;
+            }
+        }
+
+        return $max;
     }
 
     private function loadSequenceChildNode(

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -190,14 +190,14 @@ class TypesTest extends BaseTest
     /**
      * @dataProvider getMaxOccurencesOverride
      */
-    public function testSequencMaxOccursOverride($xml, $expected): void
+    public function testSequencMaxOccursOverride($sequenceMaxOccurs, $childMaxOccurs, $expected): void
     {
         $schema = $this->reader->readString(
             '
             <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:complexType name="complexType">
-                    <xs:sequence maxOccurs="' . $xml . '" >
-                        <xs:element name="el1" maxOccurs="5" type="xs:string"></xs:element>
+                    <xs:sequence maxOccurs="' . $sequenceMaxOccurs . '" >
+                        <xs:element name="el1" maxOccurs="' . $childMaxOccurs . '" type="xs:string"></xs:element>
                     </xs:sequence>
                 </xs:complexType>
             </xs:schema>'
@@ -212,10 +212,13 @@ class TypesTest extends BaseTest
     public function getMaxOccurencesOverride(): array
     {
         return [
-            ['0', 5], // maxOccurs=0 is ignored
-            ['1', 5],
-            ['2', 2], // 2 in this case just means "many"
-            ['unbounded', 2], // 2 in this case just means "many"
+            ['0', '5', 5], // maxOccurs=0 is ignored
+            ['1', '5', 5],
+            ['2', '5', 2], // 2 in this case just means "many"
+            ['4', '5', 4],
+            ['6', '5', 6],
+            ['unbounded', '5', 5],
+            ['5', 'unbounded', 5],
         ];
     }
 


### PR DESCRIPTION
Fix for issue as described in https://github.com/goetas-webservices/xsd2php/issues/135 where sequences with unbounded maxOccurs are being treated as having a limit of 2 when generating validation rules.

```
<xs:sequence maxOccurs="unbounded">
</xs:sequence>
```
Was generating validation rules as:

```
            -
                Count:
                    max: 2
                    groups:
                        - xsd_rules
```

Where they should be unlimited