### PR TITLE
Fixed default namespace not working correctly

### DIFF
--- a/src/Schema/CustomAttribute.php
+++ b/src/Schema/CustomAttribute.php
@@ -21,7 +21,7 @@ class CustomAttribute
     public function __construct(
         string $namespaceURI,
         string $name,
-        string $value
+        string $value,
     ) {
         $this->namespaceURI = $namespaceURI;
         $this->name = $name;

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -23,7 +23,7 @@ class Schema
         string $getter,
         string $name,
         ?string $namespace = null,
-        array &$calling = []
+        array &$calling = [],
     ): ?SchemaItem {
         $calling[spl_object_hash($this)] = true;
         $cid = "$getter, $name, $namespace";
@@ -62,7 +62,7 @@ class Schema
         string $getter,
         string $name,
         ?string $namespace = null,
-        array &$calling = []
+        array &$calling = [],
     ): ?SchemaItem {
         foreach ($schemas as $childSchema) {
             if (!isset($calling[spl_object_hash($childSchema)])) {

--- a/src/SchemaReader.php
+++ b/src/SchemaReader.php
@@ -151,7 +151,7 @@ class SchemaReader
 
     private function loadAttributeGroup(
         Schema $schema,
-        \DOMElement $node
+        \DOMElement $node,
     ): \Closure {
         $attGroup = new AttributeGroup($schema, $node->getAttribute('name'));
         $attGroup->setDoc($this->getDocumentation($node));
@@ -187,7 +187,7 @@ class SchemaReader
     private function getAttributeFromAttributeOrRef(
         \DOMElement $childNode,
         Schema $schema,
-        \DOMElement $node
+        \DOMElement $node,
     ): AttributeItem {
         if ($childNode->hasAttribute('ref')) {
             $attributeDef = $this->findAttributeItem($schema, $node, $childNode->getAttribute('ref'));
@@ -270,7 +270,7 @@ class SchemaReader
         Schema $schema,
         \DOMElement $node,
         \DOMElement $childNode,
-        bool $isAttribute
+        bool $isAttribute,
     ): \Closure {
         $name = $childNode->getAttribute('name');
         if ($isAttribute) {
@@ -463,7 +463,7 @@ class SchemaReader
         \DOMElement $node,
         \DOMElement $childNode,
         ?int $max,
-        ?int $min = null
+        ?int $min = null,
     ): void {
         switch ($childNode->localName) {
             case 'sequence':
@@ -518,7 +518,7 @@ class SchemaReader
         \DOMElement $node,
         \DOMElement $childNode,
         ?int $max,
-        ?int $min
+        ?int $min,
     ): void {
         $schema = $elementContainer->getSchema();
         if ($childNode->hasAttribute('ref')) {
@@ -551,7 +551,7 @@ class SchemaReader
         \DOMElement $node,
         \DOMElement $childNode,
         ?int $max,
-        ?int $min
+        ?int $min,
     ): void {
         $schema = $elementContainer->getSchema();
         $element = $this->createAnyElement($schema, $childNode);
@@ -570,7 +570,7 @@ class SchemaReader
         Schema $schema,
         \DOMElement $node,
         \DOMElement $childNode,
-        AbstractElementSingle $element
+        AbstractElementSingle $element,
     ): void {
         if ($childNode->hasAttribute('substitutionGroup')) {
             $substitutionGroup = $childNode->getAttribute('substitutionGroup');
@@ -583,7 +583,7 @@ class SchemaReader
         Schema $schema,
         \DOMElement $node,
         \DOMElement $childNode,
-        ElementContainer $elementContainer
+        ElementContainer $elementContainer,
     ): void {
         $referencedGroup = $this->findGroup(
             $schema,
@@ -598,7 +598,7 @@ class SchemaReader
     private function loadChoiceWithChildren(
         Schema $schema,
         \DOMElement $node,
-        ElementContainer $elementContainer
+        ElementContainer $elementContainer,
     ): void {
         $choice = $this->createChoice($schema, $node);
         $elementContainer->addElement($choice);
@@ -732,7 +732,7 @@ class SchemaReader
         BaseComplexType $type,
         \DOMElement $node,
         \DOMElement $childNode,
-        Schema $schema
+        Schema $schema,
     ): void {
         switch ($childNode->localName) {
             case 'sequence':
@@ -818,7 +818,7 @@ class SchemaReader
     private function findSomeType(
         SchemaItem $fromThis,
         \DOMElement $node,
-        string $attributeName
+        string $attributeName,
     ): SchemaItem {
         return $this->findSomeTypeFromAttribute(
             $fromThis,
@@ -830,7 +830,7 @@ class SchemaReader
     private function findSomeTypeFromAttribute(
         SchemaItem $fromThis,
         \DOMElement $node,
-        string $attributeName
+        string $attributeName,
     ): SchemaItem {
         return $this->findType(
             $fromThis->getSchema(),
@@ -919,7 +919,7 @@ class SchemaReader
 
     private function loadExtensionChildNodes(
         BaseComplexType $type,
-        \DOMElement $node
+        \DOMElement $node,
     ): void {
         self::againstDOMNodeList(
             $node,
@@ -941,7 +941,7 @@ class SchemaReader
     private function loadChildAttributesAndAttributeGroups(
         BaseComplexType $type,
         \DOMElement $node,
-        \DOMElement $childNode
+        \DOMElement $childNode,
     ): void {
         switch ($childNode->localName) {
             case 'attribute':
@@ -974,7 +974,7 @@ class SchemaReader
                 $node,
                 function (
                     \DOMElement $node,
-                    \DOMElement $childNode
+                    \DOMElement $childNode,
                 ) use (
                     $type,
                     $restriction
@@ -995,7 +995,7 @@ class SchemaReader
     private function loadRestrictionChildNodes(
         Type $type,
         Restriction $restriction,
-        \DOMElement $node
+        \DOMElement $node,
     ): void {
         self::againstDOMNodeList(
             $node,
@@ -1039,7 +1039,7 @@ class SchemaReader
         // If no prefix was provided and the above lookup failed, this means that there
         // was no defalut namespace defined, making the element part of no namespace.
         // In this case, we should not throw an exception since this is valid xml.
-        if (!$namespace && $prefix !== null) {
+        if (!$namespace && null !== $prefix) {
             throw new TypeException(sprintf("Can't find namespace for prefix '%s', at line %d in %s ", $prefix, $node->getLineNo(), $node->ownerDocument->documentURI));
         }
 
@@ -1199,7 +1199,7 @@ class SchemaReader
 
     private function loadImport(
         Schema $schema,
-        \DOMElement $node
+        \DOMElement $node,
     ): \Closure {
         $namespace = $node->getAttribute('namespace');
         $schemaLocation = $node->getAttribute('schemaLocation');
@@ -1253,7 +1253,7 @@ class SchemaReader
     private function loadImportFresh(
         string $namespace,
         Schema $schema,
-        string $file
+        string $file,
     ): \Closure {
         return function () use ($namespace, $schema, $file): void {
             $dom = $this->getDOM(
@@ -1539,7 +1539,7 @@ class SchemaReader
         BaseComplexType $type,
         \DOMElement $childNode,
         Schema $schema,
-        \DOMElement $node
+        \DOMElement $node,
     ): void {
         $attribute = $this->getAttributeFromAttributeOrRef(
             $childNode,
@@ -1554,7 +1554,7 @@ class SchemaReader
         Schema $schema,
         \DOMElement $node,
         \DOMElement $childNode,
-        AttributeContainer $addToThis
+        AttributeContainer $addToThis,
     ): void {
         $attribute = $this->findAttributeGroup($schema, $node, $childNode->getAttribute('ref'));
         $addToThis->addAttribute($attribute);
@@ -1585,7 +1585,7 @@ class SchemaReader
     private function setSchemaThingsFromNode(
         Schema $schema,
         \DOMElement $node,
-        ?Schema $parent = null
+        ?Schema $parent = null,
     ): void {
         $schema->setDoc($this->getDocumentation($node));
 

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -18,7 +18,7 @@ class AttributesTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:attribute name="myAttribute" type="xs:string"></xs:attribute>
                 <xs:attribute name="myAttributeOptions" type="xs:string" use="required" nil="true"></xs:attribute>
 
@@ -101,22 +101,22 @@ class AttributesTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:attribute name="lang" use="optional" type="xs:language"/>
                 <xs:element name="Name">
                     <xs:complexType mixed="true">
-                        <xs:attribute ref="lang" use="required"/>
+                        <xs:attribute ref="ex:lang" use="required"/>
                     </xs:complexType>
                 </xs:element>
                 <xs:complexType name="MyNameType">
                     <xs:sequence>
-                        <xs:element ref="Name"/>
+                        <xs:element ref="ex:Name"/>
                     </xs:sequence>
                 </xs:complexType>
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name="myName" type="MyNameType"/>
+                            <xs:element name="myName" type="ex:MyNameType"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>

--- a/tests/ChoiceTest.php
+++ b/tests/ChoiceTest.php
@@ -15,14 +15,14 @@ class ChoiceTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
                 <xs:element name="Languages">
                     <xs:complexType>
                         <xs:choice>
-                            <xs:element ref="german"/>
-                            <xs:element ref="english"/>
-                            <xs:element ref="spanish"/>
+                            <xs:element ref="ex:german"/>
+                            <xs:element ref="ex:english"/>
+                            <xs:element ref="ex:spanish"/>
                         </xs:choice>
                     </xs:complexType>
                 </xs:element>
@@ -33,7 +33,7 @@ class ChoiceTest extends BaseTest
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element ref="Languages"/>
+                            <xs:element ref="ex:Languages"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -61,14 +61,14 @@ class ChoiceTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
                 <xs:element name="Languages">
                     <xs:complexType>
                         <xs:choice minOccurs="0">
-                            <xs:element ref="german"/>
-                            <xs:element ref="english"/>
-                            <xs:element ref="spanish"/>
+                            <xs:element ref="ex:german"/>
+                            <xs:element ref="ex:english"/>
+                            <xs:element ref="ex:spanish"/>
                         </xs:choice>
                     </xs:complexType>
                 </xs:element>
@@ -79,7 +79,7 @@ class ChoiceTest extends BaseTest
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element ref="Languages"/>
+                            <xs:element ref="ex:Languages"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -107,14 +107,14 @@ class ChoiceTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
                 <xs:element name="Languages">
                     <xs:complexType>
                         <xs:choice>
-                            <xs:element ref="german"/>
-                            <xs:element ref="english"/>
-                            <xs:element ref="spanish" minOccurs="0"/>
+                            <xs:element ref="ex:german"/>
+                            <xs:element ref="ex:english"/>
+                            <xs:element ref="ex:spanish" minOccurs="0"/>
                         </xs:choice>
                     </xs:complexType>
                 </xs:element>
@@ -125,7 +125,7 @@ class ChoiceTest extends BaseTest
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element ref="Languages"/>
+                            <xs:element ref="ex:Languages"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -154,14 +154,14 @@ class ChoiceTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
                 <xs:element name="Languages">
                     <xs:complexType>
                         <xs:choice maxOccurs="unbounded">
-                            <xs:element ref="german"/>
-                            <xs:element ref="english"/>
-                            <xs:element ref="spanish"/>
+                            <xs:element ref="ex:german"/>
+                            <xs:element ref="ex:english"/>
+                            <xs:element ref="ex:spanish"/>
                         </xs:choice>
                     </xs:complexType>
                 </xs:element>
@@ -172,7 +172,7 @@ class ChoiceTest extends BaseTest
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element ref="Languages"/>
+                            <xs:element ref="ex:Languages"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -200,28 +200,28 @@ class ChoiceTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
                 <xs:element name="LunchMenu">
                     <xs:complexType>
                         <xs:sequence>
                             <xs:choice minOccurs="0">
-                                <xs:element ref="Soup1"/>
+                                <xs:element ref="ex:Soup1"/>
                                 <xs:choice>
-                                    <xs:element ref="Soup2"/>
-                                    <xs:element ref="Soup3"/>
+                                    <xs:element ref="ex:Soup2"/>
+                                    <xs:element ref="ex:Soup3"/>
                                 </xs:choice>
                             </xs:choice>
                             <xs:choice>
-                                <xs:element ref="MainMenu1"/>
+                                <xs:element ref="ex:MainMenu1"/>
                                 <xs:choice>
-                                    <xs:element ref="MainMenu2"/>
-                                    <xs:element ref="MainMenu3"/>
+                                    <xs:element ref="ex:MainMenu2"/>
+                                    <xs:element ref="ex:MainMenu3"/>
                                 </xs:choice>
                             </xs:choice>
                             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:element ref="Dessert1"/>
-                                <xs:element ref="Dessert2"/>
+                                <xs:element ref="ex:Dessert1"/>
+                                <xs:element ref="ex:Dessert2"/>
                             </xs:choice>
                         </xs:sequence>
                     </xs:complexType>
@@ -238,7 +238,7 @@ class ChoiceTest extends BaseTest
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element ref="LunchMenu"/>
+                            <xs:element ref="ex:LunchMenu"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>

--- a/tests/ElementsTest.php
+++ b/tests/ElementsTest.php
@@ -19,7 +19,7 @@ class ElementsTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:element name="myElement" type="xs:string"></xs:element>
 
                 <xs:element name="myElementAnonType">
@@ -67,19 +67,19 @@ class ElementsTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:complexType name="myType">
                     <xs:sequence>
-                        <xs:group ref="myGroup" minOccurs="1" />
-                        <xs:group ref="myGroup" minOccurs="2" />
+                        <xs:group ref="ex:myGroup" minOccurs="1" />
+                        <xs:group ref="ex:myGroup" minOccurs="2" />
 
-                        <xs:group ref="myGroup" maxOccurs="1" />
-                        <xs:group ref="myGroup" maxOccurs="unbounded" />
+                        <xs:group ref="ex:myGroup" maxOccurs="1" />
+                        <xs:group ref="ex:myGroup" maxOccurs="unbounded" />
 
-                        <xs:group ref="myGroup" minOccurs="1" maxOccurs="1"/>
-                        <xs:group ref="myGroup" minOccurs="2" maxOccurs="2"/>
+                        <xs:group ref="ex:myGroup" minOccurs="1" maxOccurs="1"/>
+                        <xs:group ref="ex:myGroup" minOccurs="2" maxOccurs="2"/>
 
-                        <xs:group ref="myGroup" minOccurs="1" maxOccurs="unbounded"/>
+                        <xs:group ref="ex:myGroup" minOccurs="1" maxOccurs="unbounded"/>
 
                     </xs:sequence>
                 </xs:complexType>
@@ -201,10 +201,10 @@ class ElementsTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:complexType name="myType">
                     <xs:sequence>
-                        <xs:group ref="myGroup" />
+                        <xs:group ref="ex:myGroup" />
                     </xs:sequence>
                 </xs:complexType>
 

--- a/tests/RestrictionsTest.php
+++ b/tests/RestrictionsTest.php
@@ -401,7 +401,7 @@ class RestrictionsTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
                 <xs:complexType name="BaseAmountType">
                   <xs:simpleContent>
@@ -416,7 +416,7 @@ class RestrictionsTest extends BaseTest
 
                 <xs:complexType name="AmountType">
                   <xs:simpleContent>
-                      <xs:restriction base="BaseAmountType">
+                      <xs:restriction base="ex:BaseAmountType">
                         <xs:attribute name="currencyID" type="xs:string" use="required">
                         </xs:attribute>
                       </xs:restriction>
@@ -426,7 +426,7 @@ class RestrictionsTest extends BaseTest
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="myAmount" type="AmountType"/>
+                          <xs:element name="myAmount" type="ex:AmountType"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -458,7 +458,7 @@ class RestrictionsTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
                 <xs:complexType name="BaseAmountType">
                   <xs:simpleContent>
@@ -473,7 +473,7 @@ class RestrictionsTest extends BaseTest
 
                 <xs:complexType name="AmountType">
                   <xs:simpleContent>
-                      <xs:restriction base="BaseAmountType">
+                      <xs:restriction base="ex:BaseAmountType">
                         <xs:attribute name="currencyID" type="xs:string" use="required">
                         </xs:attribute>
                       </xs:restriction>
@@ -482,14 +482,14 @@ class RestrictionsTest extends BaseTest
 
                 <xs:complexType name="MyAmountType">
                   <xs:simpleContent>
-                    <xs:restriction base="AmountType"/>
+                    <xs:restriction base="ex:AmountType"/>
                   </xs:simpleContent>
                 </xs:complexType>
 
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="myAmount" type="MyAmountType"/>
+                          <xs:element name="myAmount" type="ex:MyAmountType"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -523,7 +523,7 @@ class RestrictionsTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
                 <xs:complexType name="BaseQuantityType">
                   <xs:simpleContent>
@@ -535,20 +535,20 @@ class RestrictionsTest extends BaseTest
 
                 <xs:complexType name="QuantityType">
                   <xs:simpleContent>
-                    <xs:extension base="BaseQuantityType"/>
+                    <xs:extension base="ex:BaseQuantityType"/>
                   </xs:simpleContent>
                 </xs:complexType>
 
                 <xs:complexType name="MyQuantityType">
                   <xs:simpleContent>
-                    <xs:restriction base="QuantityType"/>
+                    <xs:restriction base="ex:QuantityType"/>
                   </xs:simpleContent>
                 </xs:complexType>
 
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="myQuantity" type="MyQuantityType"/>
+                          <xs:element name="myQuantity" type="ex:MyQuantityType"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -583,7 +583,7 @@ class RestrictionsTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xlmns:tns="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:tns="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <!-- SOAP 1.1 enc:Array-->
                 <xs:group name="Array">
                     <xs:sequence>

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -97,9 +97,9 @@ class SchemaTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:complexType name="myType"></xs:complexType>
-                <xs:element name="myElement" type="myType"></xs:element>
+                <xs:element name="myElement" type="ex:myType"></xs:element>
 
                 <xs:group name="myGroup">
                     <xs:sequence></xs:sequence>
@@ -131,9 +131,9 @@ class SchemaTest extends BaseTest
         $file = 'schema.xsd';
         $schema1 = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:complexType name="myType"></xs:complexType>
-                <xs:element name="myElement" type="myType"></xs:element>
+                <xs:element name="myElement" type="ex:myType"></xs:element>
 
                 <xs:group name="myGroup">
                     <xs:sequence></xs:sequence>
@@ -171,9 +171,9 @@ class SchemaTest extends BaseTest
         $file = 'schema.xsd';
         $schema1 = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:complexType name="myType"></xs:complexType>
-                <xs:element name="myElement" type="myType"></xs:element>
+                <xs:element name="myElement" type="ex:myType"></xs:element>
             </xs:schema>',
             $file
         );
@@ -187,9 +187,9 @@ class SchemaTest extends BaseTest
         // Now use a second schema which uses the same targetNamespace
         $schema2 = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:import namespace="http://www.example.com"/>
-                <xs:element name="myElement2" type="ns1:myType"></xs:element>
+                <xs:element name="myElement2" type="ex:myType"></xs:element>
             </xs:schema>',
             $file
         );
@@ -201,7 +201,7 @@ class SchemaTest extends BaseTest
         self::assertInstanceOf(ElementDef::class, $schema2->findElement('myElement2', 'http://www.example.com'));
 
         self::assertCount(1, $schema1->getTypes());
-        self::assertCount(1, $schema2->getElements());
+        self::assertCount(1, $schema1->getElements());
         self::assertInstanceOf(ElementDef::class, $schema1->findElement('myElement2', 'http://www.example.com'));
     }
 
@@ -209,10 +209,10 @@ class SchemaTest extends BaseTest
     {
         $schema1 = $this->reader->readString(
             '
-        <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
             <xs:element name="myElement">
                 <xs:complexType>
-                    <xs:group ref="myGroup"/>
+                    <xs:group ref="ex:myGroup"/>
                 </xs:complexType>
             </xs:element>
             <xs:group name="myGroup">

--- a/tests/SubstitutionGroupTest.php
+++ b/tests/SubstitutionGroupTest.php
@@ -12,22 +12,22 @@ class SubstitutionGroupTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
                 <xs:element name="language" abstract="true"/>
-                <xs:element name="german"  substitutionGroup="language"/>
-                <xs:element name="english" substitutionGroup="language"/>
-                <xs:element name="spanish" substitutionGroup="language"/>
+                <xs:element name="german"  substitutionGroup="ex:language"/>
+                <xs:element name="english" substitutionGroup="ex:language"/>
+                <xs:element name="spanish" substitutionGroup="ex:language"/>
                 <xs:complexType name="Languages">
                     <xs:sequence>
-                        <xs:element ref="language" minOccurs="1" maxOccurs="unbounded"/>
+                        <xs:element ref="ex:language" minOccurs="1" maxOccurs="unbounded"/>
                     </xs:sequence>
                 </xs:complexType>
 
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name="myLanguages" type="Languages"/>
+                            <xs:element name="myLanguages" type="ex:Languages"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -58,22 +58,22 @@ class SubstitutionGroupTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-                <xs:element name="german"  substitutionGroup="language"/>
-                <xs:element name="english" substitutionGroup="language"/>
-                <xs:element name="spanish" substitutionGroup="language"/>
+                <xs:element name="german"  substitutionGroup="ex:language"/>
+                <xs:element name="english" substitutionGroup="ex:language"/>
+                <xs:element name="spanish" substitutionGroup="ex:language"/>
                 <xs:element name="language" abstract="true"/>
                 <xs:complexType name="Languages">
                     <xs:sequence>
-                        <xs:element ref="language" minOccurs="1" maxOccurs="unbounded"/>
+                        <xs:element ref="ex:language" minOccurs="1" maxOccurs="unbounded"/>
                     </xs:sequence>
                 </xs:complexType>
 
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name="myLanguages" type="Languages"/>
+                            <xs:element name="myLanguages" type="ex:Languages"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -104,25 +104,25 @@ class SubstitutionGroupTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
                 <xs:element name="name" type="xs:string"/>
-                <xs:element name="navn" substitutionGroup="name"/>
+                <xs:element name="navn" substitutionGroup="ex:name"/>
 
                 <xs:complexType name="custinfo">
                 <xs:sequence>
-                    <xs:element ref="customer"/>
-                    <xs:element ref="name"/>
+                    <xs:element ref="ex:customer"/>
+                    <xs:element ref="ex:name"/>
                 </xs:sequence>
                 </xs:complexType>
 
                 <xs:element name="customer" type="xs:string"/>
-                <xs:element name="kunde" substitutionGroup="customer"/>
+                <xs:element name="kunde" substitutionGroup="ex:customer"/>
 
                 <xs:element name="root">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name="customerInfo" type="custinfo"/>
+                            <xs:element name="customerInfo" type="ex:custinfo"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>

--- a/tests/TypeInheritanceTest.php
+++ b/tests/TypeInheritanceTest.php
@@ -54,24 +54,24 @@ class TypeInheritanceTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
                 <xs:simpleType name="mySimple">
                     <xs:restriction base="xs:string"></xs:restriction>
                 </xs:simpleType>
 
                 <xs:simpleType name="mySimpleWithRestr">
-                    <xs:restriction base="mySimple"></xs:restriction>
+                    <xs:restriction base="ex:mySimple"></xs:restriction>
                 </xs:simpleType>
 
                 <xs:complexType name="myComplex">
                     <xs:simpleContent>
-                        <xs:extension base="mySimpleWithRestr"></xs:extension>
+                        <xs:extension base="ex:mySimpleWithRestr"></xs:extension>
                     </xs:simpleContent>
                 </xs:complexType>
 
                 <xs:simpleType name="mySimpleWithUnion">
-                    <xs:union memberTypes="xs:string mySimpleWithRestr"></xs:union>
+                    <xs:union memberTypes="xs:string ex:mySimpleWithRestr"></xs:union>
                 </xs:simpleType>
 
             </xs:schema>'

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -278,14 +278,14 @@ class TypesTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:complexType name="complexType">
                     <xs:sequence>
                         <xs:element name="el1" type="xs:string"></xs:element>
                         <xs:element name="el2">
                         </xs:element>
                         <xs:element ref="ex:el3"></xs:element>
-                        <xs:group ref="g1"></xs:group>
+                        <xs:group ref="ex:g1"></xs:group>
                     </xs:sequence>
                     <xs:attribute name="att1" type="xs:string"></xs:attribute>
                     <xs:attribute name="att2"></xs:attribute>
@@ -365,7 +365,7 @@ class TypesTest extends BaseTest
     {
         $schema = $this->reader->readString(
             '
-            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:complexType name="complexType">
                     <xs:simpleContent>
                         <xs:extension base="xs:string"></xs:extension>

--- a/tests/foo bar/referenced.xsd
+++ b/tests/foo bar/referenced.xsd
@@ -1,6 +1,6 @@
-<xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 	<xs:complexType name="myType"></xs:complexType>
-	<xs:element name="myElement" type="myType"></xs:element>
+	<xs:element name="myElement" type="ex:myType"></xs:element>
 
 	<xs:group name="myGroup">
 		<xs:sequence></xs:sequence>


### PR DESCRIPTION
From my understanding, the code does not handle cases correctly where there are default namespaces supposed to be used by an xsd file. Rather, the code assumes the default namespace to be the targetNamespace, which is incorrect. This bugfix fixes the behavior to work as intended by W3C XML Schema.

Two other bugs were fixed along the way:

- The implicit anyType for an element - if the namespace http://www.w3.org/2001/XMLSchema was the default namespace - would be passed as ':anyType' instead of just 'anyType' which led to wrong behavior later on.
- If an element used a namespace prefix and that namespace could not be found in the schema, the code just assumed that the element's namespace was the target namespace, which was incorrect. In this case, an error will now be thrown.

Consider this example:

```xml
<schema targetNamespace="http://www.example.com" xmlns="http://www.w3.org/2001/XMLSchema">
    <attribute name="myCustomAttribute" type="int"/>
</schema>
```

The default namespace is defined as http://www.w3.org/2001/XMLSchema. Thus, every child element of schema (the attribute element as well as the type int) belongs to this namespace. The code, however, assumes during its validation process that the type int belongs to the targetNamespace http://www.example.com/ and looks for its definition there, where it is obviously not going to find it since this namespace only defines the attribute myCustomAttribute and nothing else. So the code throws an error.

With the bugfix applied, the code assumes the correct default namespace of http://www.w3.org/2001/XMLSchema to be the one in which to look for the definition of type int for, thus not throwing an error.

There is an edge case here where no default namespace could be defined in the schema above, and it could still be valid XSD. The type int would be in no namespace. The code, however, throws an error without further validation. To validate this edge case correctly, the code would have to look for the definition of type int in the imported schemas that define 'no namespace' components, which are indicated by the 'noNamespaceSchemaLocation' attribute in the http://www.w3.org/2001/XMLSchema-instance namespace. This edge case would require some more refactoring within the namespace handling and is therefore ignored within this bugfix. I will probably look into it later on.

The tests also had to be adapted to match the new logic. In general, I added the xmlns:ex=http://www.example.com/ attribute to the schema element to define the 'ex' prefix for the namespace http://www.example.com/, which was the targetNamespace for all the tests that needed changing. I then also had to reference the components defined in the schemas by prefixing them with the 'ex' prefix since I did not provide a default namespace, and otherwise we would be in the edge case above. Lastly, I added 2 new tests to check if the default namespace is used correctly and that an unknown namespace to the schema fails the validation.

For further information, https://www.oracle.com/technical-resources/articles/srivastava-namespaces.html explains very well how default namespace and targetNamespace work within XSD.