### PR TITLE
Change max occurs override logic

### DIFF
--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1725010415">
-  <project timestamp="1725010415">
+<coverage generated="1735905392">
+  <project timestamp="1735905392">
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Documentation/DocumentationReader.php">
       <metrics loc="11" ncloc="11" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
     </file>
@@ -8,17 +8,17 @@
       <class name="GoetasWebservices\XML\XSDReader\Documentation\StandardDocumentationReader" namespace="global">
         <metrics complexity="8" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="10" coveredstatements="10" elements="11" coveredelements="11"/>
       </class>
-      <line num="9" type="method" name="get" visibility="public" complexity="8" crap="8" count="109"/>
-      <line num="11" type="stmt" count="109"/>
-      <line num="16" type="stmt" count="109"/>
-      <line num="17" type="stmt" count="109"/>
-      <line num="21" type="stmt" count="109"/>
-      <line num="22" type="stmt" count="109"/>
-      <line num="23" type="stmt" count="108"/>
-      <line num="24" type="stmt" count="104"/>
-      <line num="26" type="stmt" count="108"/>
-      <line num="32" type="stmt" count="109"/>
-      <line num="34" type="stmt" count="109"/>
+      <line num="9" type="method" name="get" visibility="public" complexity="8" crap="8" count="118"/>
+      <line num="11" type="stmt" count="118"/>
+      <line num="16" type="stmt" count="118"/>
+      <line num="17" type="stmt" count="118"/>
+      <line num="21" type="stmt" count="118"/>
+      <line num="22" type="stmt" count="118"/>
+      <line num="23" type="stmt" count="117"/>
+      <line num="24" type="stmt" count="113"/>
+      <line num="26" type="stmt" count="117"/>
+      <line num="32" type="stmt" count="118"/>
+      <line num="34" type="stmt" count="118"/>
       <metrics loc="37" ncloc="31" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="10" coveredstatements="10" elements="11" coveredelements="11"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Exception/IOException.php">
@@ -37,15 +37,15 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\AbstractNamedGroupItem" namespace="global">
         <metrics complexity="4" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="4" elements="9" coveredelements="7"/>
       </class>
-      <line num="15" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="17" type="stmt" count="104"/>
-      <line num="18" type="stmt" count="104"/>
+      <line num="15" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="17" type="stmt" count="113"/>
+      <line num="18" type="stmt" count="113"/>
       <line num="21" type="method" name="getDoc" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="23" type="stmt" count="0"/>
-      <line num="26" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="28" type="stmt" count="104"/>
-      <line num="31" type="method" name="getSchema" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="33" type="stmt" count="104"/>
+      <line num="26" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="28" type="stmt" count="113"/>
+      <line num="31" type="method" name="getSchema" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="33" type="stmt" count="113"/>
       <metrics loc="36" ncloc="36" classes="1" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="4" elements="9" coveredelements="7"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Attribute/AbstractAttributeItem.php">
@@ -58,20 +58,20 @@
       <line num="31" type="stmt" count="0"/>
       <line num="34" type="method" name="getDefault" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="36" type="stmt" count="0"/>
-      <line num="39" type="method" name="setDefault" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="41" type="stmt" count="104"/>
+      <line num="39" type="method" name="setDefault" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="41" type="stmt" count="113"/>
       <line num="44" type="method" name="isQualified" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="46" type="stmt" count="2"/>
-      <line num="49" type="method" name="setQualified" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="51" type="stmt" count="104"/>
+      <line num="49" type="method" name="setQualified" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="51" type="stmt" count="113"/>
       <line num="54" type="method" name="isNil" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="56" type="stmt" count="1"/>
       <line num="59" type="method" name="setNil" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="61" type="stmt" count="1"/>
       <line num="64" type="method" name="getUse" visibility="public" complexity="1" crap="1" count="5"/>
       <line num="66" type="stmt" count="5"/>
-      <line num="69" type="method" name="setUse" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="71" type="stmt" count="104"/>
+      <line num="69" type="method" name="setUse" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="71" type="stmt" count="113"/>
       <metrics loc="74" ncloc="74" classes="1" methods="10" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="10" coveredstatements="7" elements="20" coveredelements="14"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Attribute/Attribute.php">
@@ -87,8 +87,8 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeContainerTrait" namespace="global">
         <metrics complexity="2" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
       </class>
-      <line num="14" type="method" name="addAttribute" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="16" type="stmt" count="104"/>
+      <line num="14" type="method" name="addAttribute" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="16" type="stmt" count="113"/>
       <line num="22" type="method" name="getAttributes" visibility="public" complexity="1" crap="1" count="12"/>
       <line num="24" type="stmt" count="12"/>
       <metrics loc="27" ncloc="21" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
@@ -106,9 +106,9 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeRef" namespace="global">
         <metrics complexity="4" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="5" elements="9" coveredelements="9"/>
       </class>
-      <line num="13" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="15" type="stmt" count="104"/>
-      <line num="16" type="stmt" count="104"/>
+      <line num="13" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="15" type="stmt" count="113"/>
+      <line num="16" type="stmt" count="113"/>
       <line num="19" type="method" name="getName" visibility="public" complexity="1" crap="1" count="3"/>
       <line num="21" type="stmt" count="3"/>
       <line num="24" type="method" name="getReferencedAttribute" visibility="public" complexity="1" crap="1" count="2"/>
@@ -151,8 +151,8 @@
       </class>
       <line num="17" type="method" name="getCustomAttributes" visibility="public" complexity="1" crap="1" count="5"/>
       <line num="19" type="stmt" count="5"/>
-      <line num="25" type="method" name="setCustomAttributes" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="27" type="stmt" count="104"/>
+      <line num="25" type="method" name="setCustomAttributes" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="27" type="stmt" count="113"/>
       <metrics loc="30" ncloc="21" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Element/AbstractElementSingle.php">
@@ -161,24 +161,24 @@
       </class>
       <line num="30" type="method" name="isQualified" visibility="public" complexity="1" crap="1" count="3"/>
       <line num="32" type="stmt" count="3"/>
-      <line num="35" type="method" name="setQualified" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="37" type="stmt" count="104"/>
-      <line num="40" type="method" name="isLocal" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="42" type="stmt" count="104"/>
-      <line num="45" type="method" name="setLocal" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="47" type="stmt" count="104"/>
+      <line num="35" type="method" name="setQualified" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="37" type="stmt" count="113"/>
+      <line num="40" type="method" name="isLocal" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="42" type="stmt" count="113"/>
+      <line num="45" type="method" name="setLocal" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="47" type="stmt" count="113"/>
       <line num="50" type="method" name="isNil" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="52" type="stmt" count="1"/>
       <line num="55" type="method" name="setNil" visibility="public" complexity="1" crap="1" count="4"/>
       <line num="57" type="stmt" count="4"/>
-      <line num="60" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="62" type="stmt" count="104"/>
-      <line num="65" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="67" type="stmt" count="104"/>
-      <line num="70" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="72" type="stmt" count="104"/>
-      <line num="75" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="77" type="stmt" count="104"/>
+      <line num="60" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="62" type="stmt" count="113"/>
+      <line num="65" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="67" type="stmt" count="113"/>
+      <line num="70" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="72" type="stmt" count="113"/>
+      <line num="75" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="77" type="stmt" count="113"/>
       <line num="80" type="method" name="getFixed" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="82" type="stmt" count="0"/>
       <line num="85" type="method" name="setFixed" visibility="public" complexity="1" crap="2" count="0"/>
@@ -197,8 +197,8 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\Any\Any" namespace="global">
         <metrics complexity="8" methods="8" coveredmethods="8" conditionals="0" coveredconditionals="0" statements="8" coveredstatements="8" elements="16" coveredelements="16"/>
       </class>
-      <line num="26" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="28" type="stmt" count="104"/>
+      <line num="26" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="28" type="stmt" count="113"/>
       <line num="31" type="method" name="getName" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="33" type="stmt" count="2"/>
       <line num="36" type="method" name="getNamespace" visibility="public" complexity="1" crap="1" count="2"/>
@@ -207,8 +207,8 @@
       <line num="43" type="stmt" count="3"/>
       <line num="46" type="method" name="getProcessContents" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="48" type="stmt" count="2"/>
-      <line num="51" type="method" name="setProcessContents" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="53" type="stmt" count="104"/>
+      <line num="51" type="method" name="setProcessContents" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="53" type="stmt" count="113"/>
       <line num="56" type="method" name="getId" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="58" type="stmt" count="2"/>
       <line num="61" type="method" name="setId" visibility="public" complexity="1" crap="1" count="2"/>
@@ -242,10 +242,10 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\ElementContainerTrait" namespace="global">
         <metrics complexity="2" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
       </class>
-      <line num="17" type="method" name="getElements" visibility="public" complexity="1" crap="1" count="59"/>
-      <line num="19" type="stmt" count="59"/>
-      <line num="22" type="method" name="addElement" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="24" type="stmt" count="104"/>
+      <line num="17" type="method" name="getElements" visibility="public" complexity="1" crap="1" count="66"/>
+      <line num="19" type="stmt" count="66"/>
+      <line num="22" type="method" name="addElement" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="24" type="stmt" count="113"/>
       <metrics loc="27" ncloc="21" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Element/ElementDef.php">
@@ -269,13 +269,13 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\ElementRef" namespace="global">
         <metrics complexity="4" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="5" elements="9" coveredelements="9"/>
       </class>
-      <line num="13" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="15" type="stmt" count="104"/>
-      <line num="16" type="stmt" count="104"/>
+      <line num="13" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="15" type="stmt" count="113"/>
+      <line num="16" type="stmt" count="113"/>
       <line num="19" type="method" name="getName" visibility="public" complexity="1" crap="1" count="7"/>
       <line num="21" type="stmt" count="7"/>
-      <line num="24" type="method" name="getReferencedElement" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="26" type="stmt" count="104"/>
+      <line num="24" type="method" name="getReferencedElement" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="26" type="stmt" count="113"/>
       <line num="29" type="method" name="getType" visibility="public" complexity="1" crap="1" count="6"/>
       <line num="31" type="stmt" count="6"/>
       <metrics loc="34" ncloc="34" classes="1" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="5" elements="9" coveredelements="9"/>
@@ -293,17 +293,17 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\GroupRef" namespace="global">
         <metrics complexity="13" methods="8" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="17" coveredstatements="16" elements="25" coveredelements="23"/>
       </class>
-      <line num="15" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="17" type="stmt" count="104"/>
-      <line num="18" type="stmt" count="104"/>
-      <line num="21" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="23" type="stmt" count="104"/>
-      <line num="26" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="28" type="stmt" count="104"/>
-      <line num="31" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="33" type="stmt" count="104"/>
-      <line num="36" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="38" type="stmt" count="104"/>
+      <line num="15" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="17" type="stmt" count="113"/>
+      <line num="18" type="stmt" count="113"/>
+      <line num="21" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="23" type="stmt" count="113"/>
+      <line num="26" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="28" type="stmt" count="113"/>
+      <line num="31" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="33" type="stmt" count="113"/>
+      <line num="36" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="38" type="stmt" count="113"/>
       <line num="41" type="method" name="getName" visibility="public" complexity="1" crap="1" count="9"/>
       <line num="43" type="stmt" count="9"/>
       <line num="49" type="method" name="getElements" visibility="public" complexity="6" crap="6" count="8"/>
@@ -336,14 +336,14 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\MinMaxTrait" namespace="global">
         <metrics complexity="4" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="4" elements="8" coveredelements="8"/>
       </class>
-      <line num="13" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="15" type="stmt" count="104"/>
-      <line num="18" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="20" type="stmt" count="104"/>
-      <line num="23" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="25" type="stmt" count="104"/>
-      <line num="28" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="30" type="stmt" count="104"/>
+      <line num="13" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="15" type="stmt" count="113"/>
+      <line num="18" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="20" type="stmt" count="113"/>
+      <line num="23" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="25" type="stmt" count="113"/>
+      <line num="28" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="30" type="stmt" count="113"/>
       <metrics loc="33" ncloc="33" classes="1" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="4" elements="8" coveredelements="8"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Element/Sequence.php">
@@ -370,9 +370,9 @@
       </class>
       <line num="13" type="method" name="getBase" visibility="public" complexity="1" crap="1" count="11"/>
       <line num="15" type="stmt" count="11"/>
-      <line num="18" type="method" name="setBase" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="20" type="stmt" count="104"/>
-      <line num="22" type="stmt" count="104"/>
+      <line num="18" type="method" name="setBase" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="20" type="stmt" count="113"/>
+      <line num="22" type="stmt" count="113"/>
       <metrics loc="25" ncloc="25" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="3" elements="5" coveredelements="5"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Inheritance/Extension.php">
@@ -385,8 +385,8 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Inheritance\Restriction" namespace="global">
         <metrics complexity="3" methods="3" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="6" coveredelements="4"/>
       </class>
-      <line num="17" type="method" name="addCheck" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="19" type="stmt" count="104"/>
+      <line num="17" type="method" name="addCheck" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="19" type="stmt" count="113"/>
       <line num="25" type="method" name="getChecks" visibility="public" complexity="1" crap="1" count="10"/>
       <line num="27" type="stmt" count="10"/>
       <line num="33" type="method" name="getChecksByType" visibility="public" complexity="1" crap="2" count="0"/>
@@ -400,158 +400,158 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Item" namespace="global">
         <metrics complexity="3" methods="3" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="4" elements="7" coveredelements="7"/>
       </class>
-      <line num="16" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="18" type="stmt" count="104"/>
-      <line num="19" type="stmt" count="104"/>
+      <line num="16" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="18" type="stmt" count="113"/>
+      <line num="19" type="stmt" count="113"/>
       <line num="22" type="method" name="getType" visibility="public" complexity="1" crap="1" count="39"/>
       <line num="24" type="stmt" count="39"/>
-      <line num="27" type="method" name="setType" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="29" type="stmt" count="104"/>
+      <line num="27" type="method" name="setType" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="29" type="stmt" count="113"/>
       <metrics loc="32" ncloc="32" classes="1" methods="3" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="4" elements="7" coveredelements="7"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/NamedItemTrait.php">
       <class name="GoetasWebservices\XML\XSDReader\Schema\NamedItemTrait" namespace="global">
         <metrics complexity="2" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
       </class>
-      <line num="11" type="method" name="getName" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="13" type="stmt" count="104"/>
-      <line num="16" type="method" name="setName" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="18" type="stmt" count="104"/>
+      <line num="11" type="method" name="getName" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="13" type="stmt" count="113"/>
+      <line num="16" type="method" name="setName" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="18" type="stmt" count="113"/>
       <metrics loc="21" ncloc="21" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Schema.php">
       <class name="GoetasWebservices\XML\XSDReader\Schema\Schema" namespace="global">
         <metrics complexity="54" methods="34" coveredmethods="23" conditionals="0" coveredconditionals="0" statements="95" coveredstatements="84" elements="129" coveredelements="107"/>
       </class>
-      <line num="22" type="method" name="findSomethingNoThrow" visibility="protected" complexity="4" crap="4" count="104"/>
-      <line num="28" type="stmt" count="104"/>
-      <line num="29" type="stmt" count="104"/>
-      <line num="31" type="stmt" count="104"/>
-      <line num="32" type="stmt" count="104"/>
-      <line num="35" type="stmt" count="104"/>
-      <line num="39" type="stmt" count="104"/>
-      <line num="40" type="stmt" count="104"/>
-      <line num="41" type="stmt" count="104"/>
-      <line num="45" type="stmt" count="104"/>
-      <line num="46" type="stmt" count="104"/>
-      <line num="47" type="stmt" count="104"/>
-      <line num="48" type="stmt" count="104"/>
-      <line num="49" type="stmt" count="104"/>
-      <line num="50" type="stmt" count="104"/>
-      <line num="51" type="stmt" count="104"/>
-      <line num="52" type="stmt" count="104"/>
-      <line num="59" type="method" name="findSomethingNoThrowSchemas" visibility="protected" complexity="4" crap="4" count="104"/>
-      <line num="67" type="stmt" count="104"/>
-      <line num="68" type="stmt" count="104"/>
-      <line num="72" type="stmt" count="104"/>
-      <line num="74" type="stmt" count="104"/>
-      <line num="75" type="stmt" count="104"/>
-      <line num="80" type="stmt" count="14"/>
-      <line num="88" type="method" name="findSomething" visibility="protected" complexity="2" crap="2" count="104"/>
-      <line num="90" type="stmt" count="104"/>
-      <line num="91" type="stmt" count="104"/>
-      <line num="92" type="stmt" count="104"/>
-      <line num="93" type="stmt" count="104"/>
-      <line num="94" type="stmt" count="104"/>
-      <line num="95" type="stmt" count="104"/>
-      <line num="97" type="stmt" count="104"/>
-      <line num="98" type="stmt" count="104"/>
-      <line num="101" type="stmt" count="6"/>
-      <line num="147" type="method" name="getElementsQualification" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="149" type="stmt" count="104"/>
-      <line num="152" type="method" name="setElementsQualification" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="154" type="stmt" count="104"/>
-      <line num="157" type="method" name="getAttributesQualification" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="159" type="stmt" count="104"/>
-      <line num="162" type="method" name="setAttributesQualification" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="164" type="stmt" count="104"/>
-      <line num="167" type="method" name="getTargetNamespace" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="169" type="stmt" count="104"/>
-      <line num="172" type="method" name="setTargetNamespace" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="174" type="stmt" count="104"/>
+      <line num="22" type="method" name="findSomethingNoThrow" visibility="protected" complexity="4" crap="4" count="113"/>
+      <line num="28" type="stmt" count="113"/>
+      <line num="29" type="stmt" count="113"/>
+      <line num="31" type="stmt" count="113"/>
+      <line num="32" type="stmt" count="113"/>
+      <line num="35" type="stmt" count="113"/>
+      <line num="39" type="stmt" count="113"/>
+      <line num="40" type="stmt" count="113"/>
+      <line num="41" type="stmt" count="113"/>
+      <line num="45" type="stmt" count="113"/>
+      <line num="46" type="stmt" count="113"/>
+      <line num="47" type="stmt" count="113"/>
+      <line num="48" type="stmt" count="113"/>
+      <line num="49" type="stmt" count="113"/>
+      <line num="50" type="stmt" count="113"/>
+      <line num="51" type="stmt" count="113"/>
+      <line num="52" type="stmt" count="113"/>
+      <line num="59" type="method" name="findSomethingNoThrowSchemas" visibility="protected" complexity="4" crap="4" count="113"/>
+      <line num="67" type="stmt" count="113"/>
+      <line num="68" type="stmt" count="113"/>
+      <line num="72" type="stmt" count="113"/>
+      <line num="74" type="stmt" count="113"/>
+      <line num="75" type="stmt" count="113"/>
+      <line num="80" type="stmt" count="15"/>
+      <line num="88" type="method" name="findSomething" visibility="protected" complexity="2" crap="2" count="113"/>
+      <line num="90" type="stmt" count="113"/>
+      <line num="91" type="stmt" count="113"/>
+      <line num="92" type="stmt" count="113"/>
+      <line num="93" type="stmt" count="113"/>
+      <line num="94" type="stmt" count="113"/>
+      <line num="95" type="stmt" count="113"/>
+      <line num="97" type="stmt" count="113"/>
+      <line num="98" type="stmt" count="113"/>
+      <line num="101" type="stmt" count="7"/>
+      <line num="147" type="method" name="getElementsQualification" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="149" type="stmt" count="113"/>
+      <line num="152" type="method" name="setElementsQualification" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="154" type="stmt" count="113"/>
+      <line num="157" type="method" name="getAttributesQualification" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="159" type="stmt" count="113"/>
+      <line num="162" type="method" name="setAttributesQualification" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="164" type="stmt" count="113"/>
+      <line num="167" type="method" name="getTargetNamespace" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="169" type="stmt" count="113"/>
+      <line num="172" type="method" name="setTargetNamespace" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="174" type="stmt" count="113"/>
       <line num="180" type="method" name="getTypes" visibility="public" complexity="1" crap="1" count="7"/>
       <line num="182" type="stmt" count="7"/>
       <line num="188" type="method" name="getElements" visibility="public" complexity="1" crap="1" count="17"/>
       <line num="190" type="stmt" count="17"/>
-      <line num="196" type="method" name="getSchemas" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="198" type="stmt" count="104"/>
+      <line num="196" type="method" name="getSchemas" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="198" type="stmt" count="113"/>
       <line num="204" type="method" name="getAttributes" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="206" type="stmt" count="1"/>
       <line num="212" type="method" name="getGroups" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="214" type="stmt" count="2"/>
       <line num="217" type="method" name="getDoc" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="219" type="stmt" count="0"/>
-      <line num="222" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="224" type="stmt" count="104"/>
-      <line num="227" type="method" name="addType" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="229" type="stmt" count="104"/>
-      <line num="232" type="method" name="addElement" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="234" type="stmt" count="104"/>
-      <line num="237" type="method" name="addSchema" visibility="public" complexity="4" crap="4.02" count="104"/>
-      <line num="239" type="stmt" count="104"/>
-      <line num="240" type="stmt" count="104"/>
-      <line num="242" type="stmt" count="104"/>
-      <line num="245" type="stmt" count="104"/>
+      <line num="222" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="224" type="stmt" count="113"/>
+      <line num="227" type="method" name="addType" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="229" type="stmt" count="113"/>
+      <line num="232" type="method" name="addElement" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="234" type="stmt" count="113"/>
+      <line num="237" type="method" name="addSchema" visibility="public" complexity="4" crap="4.02" count="113"/>
+      <line num="239" type="stmt" count="113"/>
+      <line num="240" type="stmt" count="113"/>
+      <line num="242" type="stmt" count="113"/>
+      <line num="245" type="stmt" count="113"/>
       <line num="246" type="stmt" count="0"/>
-      <line num="249" type="stmt" count="104"/>
+      <line num="249" type="stmt" count="113"/>
       <line num="250" type="stmt" count="1"/>
       <line num="252" type="stmt" count="1"/>
-      <line num="255" type="stmt" count="104"/>
-      <line num="258" type="method" name="addAttribute" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="260" type="stmt" count="104"/>
-      <line num="263" type="method" name="addGroup" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="265" type="stmt" count="104"/>
-      <line num="268" type="method" name="addAttributeGroup" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="270" type="stmt" count="104"/>
+      <line num="255" type="stmt" count="113"/>
+      <line num="258" type="method" name="addAttribute" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="260" type="stmt" count="113"/>
+      <line num="263" type="method" name="addGroup" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="265" type="stmt" count="113"/>
+      <line num="268" type="method" name="addAttributeGroup" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="270" type="stmt" count="113"/>
       <line num="276" type="method" name="getAttributeGroups" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="278" type="stmt" count="1"/>
-      <line num="281" type="method" name="getGroup" visibility="public" complexity="2" crap="2.15" count="104"/>
-      <line num="283" type="stmt" count="104"/>
-      <line num="284" type="stmt" count="104"/>
+      <line num="281" type="method" name="getGroup" visibility="public" complexity="2" crap="2.15" count="113"/>
+      <line num="283" type="stmt" count="113"/>
+      <line num="284" type="stmt" count="113"/>
       <line num="287" type="stmt" count="0"/>
-      <line num="290" type="method" name="getElement" visibility="public" complexity="2" crap="2" count="104"/>
-      <line num="292" type="stmt" count="104"/>
-      <line num="293" type="stmt" count="104"/>
+      <line num="290" type="method" name="getElement" visibility="public" complexity="2" crap="2" count="113"/>
+      <line num="292" type="stmt" count="113"/>
+      <line num="293" type="stmt" count="113"/>
       <line num="296" type="stmt" count="1"/>
-      <line num="299" type="method" name="getType" visibility="public" complexity="2" crap="2" count="104"/>
-      <line num="301" type="stmt" count="104"/>
-      <line num="302" type="stmt" count="104"/>
+      <line num="299" type="method" name="getType" visibility="public" complexity="2" crap="2" count="113"/>
+      <line num="301" type="stmt" count="113"/>
+      <line num="302" type="stmt" count="113"/>
       <line num="305" type="stmt" count="1"/>
-      <line num="308" type="method" name="getAttribute" visibility="public" complexity="2" crap="2.15" count="104"/>
-      <line num="310" type="stmt" count="104"/>
-      <line num="311" type="stmt" count="104"/>
+      <line num="308" type="method" name="getAttribute" visibility="public" complexity="2" crap="2.15" count="113"/>
+      <line num="310" type="stmt" count="113"/>
+      <line num="311" type="stmt" count="113"/>
       <line num="314" type="stmt" count="0"/>
-      <line num="317" type="method" name="getAttributeGroup" visibility="public" complexity="2" crap="2.15" count="104"/>
-      <line num="319" type="stmt" count="104"/>
-      <line num="320" type="stmt" count="104"/>
+      <line num="317" type="method" name="getAttributeGroup" visibility="public" complexity="2" crap="2.15" count="113"/>
+      <line num="319" type="stmt" count="113"/>
+      <line num="320" type="stmt" count="113"/>
       <line num="323" type="stmt" count="0"/>
       <line num="326" type="method" name="__toString" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="328" type="stmt" count="0"/>
-      <line num="331" type="method" name="findType" visibility="public" complexity="2" crap="2.06" count="104"/>
-      <line num="333" type="stmt" count="104"/>
-      <line num="335" type="stmt" count="104"/>
+      <line num="331" type="method" name="findType" visibility="public" complexity="2" crap="2.06" count="113"/>
+      <line num="333" type="stmt" count="113"/>
+      <line num="335" type="stmt" count="113"/>
       <line num="336" type="stmt" count="0"/>
-      <line num="339" type="stmt" count="104"/>
-      <line num="342" type="method" name="findGroup" visibility="public" complexity="2" crap="2.06" count="104"/>
-      <line num="344" type="stmt" count="104"/>
-      <line num="346" type="stmt" count="104"/>
+      <line num="339" type="stmt" count="113"/>
+      <line num="342" type="method" name="findGroup" visibility="public" complexity="2" crap="2.06" count="113"/>
+      <line num="344" type="stmt" count="113"/>
+      <line num="346" type="stmt" count="113"/>
       <line num="347" type="stmt" count="0"/>
-      <line num="350" type="stmt" count="104"/>
-      <line num="353" type="method" name="findElement" visibility="public" complexity="2" crap="2.06" count="104"/>
-      <line num="355" type="stmt" count="104"/>
-      <line num="357" type="stmt" count="104"/>
+      <line num="350" type="stmt" count="113"/>
+      <line num="353" type="method" name="findElement" visibility="public" complexity="2" crap="2.06" count="113"/>
+      <line num="355" type="stmt" count="113"/>
+      <line num="357" type="stmt" count="113"/>
       <line num="358" type="stmt" count="0"/>
-      <line num="361" type="stmt" count="104"/>
-      <line num="364" type="method" name="findAttribute" visibility="public" complexity="2" crap="2.06" count="104"/>
-      <line num="366" type="stmt" count="104"/>
-      <line num="368" type="stmt" count="104"/>
+      <line num="361" type="stmt" count="113"/>
+      <line num="364" type="method" name="findAttribute" visibility="public" complexity="2" crap="2.06" count="113"/>
+      <line num="366" type="stmt" count="113"/>
+      <line num="368" type="stmt" count="113"/>
       <line num="369" type="stmt" count="0"/>
-      <line num="372" type="stmt" count="104"/>
-      <line num="375" type="method" name="findAttributeGroup" visibility="public" complexity="2" crap="2.06" count="104"/>
-      <line num="377" type="stmt" count="104"/>
-      <line num="379" type="stmt" count="104"/>
+      <line num="372" type="stmt" count="113"/>
+      <line num="375" type="method" name="findAttributeGroup" visibility="public" complexity="2" crap="2.06" count="113"/>
+      <line num="377" type="stmt" count="113"/>
+      <line num="379" type="stmt" count="113"/>
       <line num="380" type="stmt" count="0"/>
-      <line num="383" type="stmt" count="104"/>
+      <line num="383" type="stmt" count="113"/>
       <metrics loc="386" ncloc="329" classes="1" methods="34" coveredmethods="23" conditionals="0" coveredconditionals="0" statements="95" coveredstatements="84" elements="129" coveredelements="107"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/SchemaItem.php">
@@ -561,12 +561,12 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\SchemaItemTrait" namespace="global">
         <metrics complexity="3" methods="3" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="3" elements="6" coveredelements="6"/>
       </class>
-      <line num="13" type="method" name="getSchema" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="15" type="stmt" count="104"/>
+      <line num="13" type="method" name="getSchema" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="15" type="stmt" count="113"/>
       <line num="18" type="method" name="getDoc" visibility="public" complexity="1" crap="1" count="4"/>
       <line num="20" type="stmt" count="4"/>
-      <line num="23" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="25" type="stmt" count="104"/>
+      <line num="23" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="25" type="stmt" count="113"/>
       <metrics loc="28" ncloc="28" classes="1" methods="3" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="3" elements="6" coveredelements="6"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Type/BaseComplexType.php">
@@ -581,9 +581,9 @@
       </class>
       <line num="16" type="method" name="isMixed" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="18" type="stmt" count="1"/>
-      <line num="21" type="method" name="setMixed" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="23" type="stmt" count="104"/>
-      <line num="25" type="stmt" count="104"/>
+      <line num="21" type="method" name="setMixed" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="23" type="stmt" count="113"/>
+      <line num="25" type="stmt" count="113"/>
       <metrics loc="28" ncloc="28" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="3" elements="5" coveredelements="5"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Type/ComplexTypeSimpleContent.php">
@@ -596,46 +596,46 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Type\SimpleType" namespace="global">
         <metrics complexity="4" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="3" elements="8" coveredelements="6"/>
       </class>
-      <line num="16" type="method" name="addUnion" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="18" type="stmt" count="104"/>
+      <line num="16" type="method" name="addUnion" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="18" type="stmt" count="113"/>
       <line num="24" type="method" name="getUnions" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="26" type="stmt" count="2"/>
       <line num="29" type="method" name="getList" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="31" type="stmt" count="0"/>
-      <line num="34" type="method" name="setList" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="36" type="stmt" count="104"/>
+      <line num="34" type="method" name="setList" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="36" type="stmt" count="113"/>
       <metrics loc="39" ncloc="33" classes="1" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="3" elements="8" coveredelements="6"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Type/Type.php">
       <class name="GoetasWebservices\XML\XSDReader\Schema\Type\Type" namespace="global">
         <metrics complexity="12" methods="10" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="11" coveredstatements="8" elements="21" coveredelements="15"/>
       </class>
-      <line num="27" type="method" name="__construct" visibility="public" complexity="2" crap="2" count="104"/>
-      <line num="29" type="stmt" count="104"/>
-      <line num="30" type="stmt" count="104"/>
-      <line num="33" type="method" name="getName" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="35" type="stmt" count="104"/>
+      <line num="27" type="method" name="__construct" visibility="public" complexity="2" crap="2" count="113"/>
+      <line num="29" type="stmt" count="113"/>
+      <line num="30" type="stmt" count="113"/>
+      <line num="33" type="method" name="getName" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="35" type="stmt" count="113"/>
       <line num="38" type="method" name="__toString" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="40" type="stmt" count="0"/>
       <line num="43" type="method" name="isAbstract" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="45" type="stmt" count="0"/>
-      <line num="48" type="method" name="setAbstract" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="50" type="stmt" count="104"/>
+      <line num="48" type="method" name="setAbstract" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="50" type="stmt" count="113"/>
       <line num="56" type="method" name="getParent" visibility="public" complexity="2" crap="6" count="0"/>
       <line num="58" type="stmt" count="0"/>
       <line num="61" type="method" name="getRestriction" visibility="public" complexity="1" crap="1" count="19"/>
       <line num="63" type="stmt" count="19"/>
-      <line num="66" type="method" name="setRestriction" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="68" type="stmt" count="104"/>
+      <line num="66" type="method" name="setRestriction" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="68" type="stmt" count="113"/>
       <line num="71" type="method" name="getExtension" visibility="public" complexity="1" crap="1" count="4"/>
       <line num="73" type="stmt" count="4"/>
-      <line num="76" type="method" name="setExtension" visibility="public" complexity="1" crap="1" count="104"/>
-      <line num="78" type="stmt" count="104"/>
+      <line num="76" type="method" name="setExtension" visibility="public" complexity="1" crap="1" count="113"/>
+      <line num="78" type="stmt" count="113"/>
       <metrics loc="81" ncloc="78" classes="1" methods="10" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="11" coveredstatements="8" elements="21" coveredelements="15"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/SchemaReader.php">
       <class name="GoetasWebservices\XML\XSDReader\SchemaReader" namespace="global">
-        <metrics complexity="244" methods="76" coveredmethods="63" conditionals="0" coveredconditionals="0" statements="783" coveredstatements="750" elements="859" coveredelements="813"/>
+        <metrics complexity="241" methods="76" coveredmethods="62" conditionals="0" coveredconditionals="0" statements="785" coveredstatements="752" elements="861" coveredelements="814"/>
       </class>
       <line num="108" type="method" name="extractErrorMessage" visibility="private" complexity="2" crap="2" count="2"/>
       <line num="110" type="stmt" count="2"/>
@@ -644,32 +644,32 @@
       <line num="115" type="stmt" count="2"/>
       <line num="116" type="stmt" count="2"/>
       <line num="118" type="stmt" count="2"/>
-      <line num="121" type="method" name="__construct" visibility="public" complexity="2" crap="2" count="115"/>
-      <line num="123" type="stmt" count="115"/>
-      <line num="124" type="stmt" count="115"/>
-      <line num="126" type="stmt" count="115"/>
+      <line num="121" type="method" name="__construct" visibility="public" complexity="2" crap="2" count="124"/>
+      <line num="123" type="stmt" count="124"/>
+      <line num="124" type="stmt" count="124"/>
+      <line num="126" type="stmt" count="124"/>
       <line num="135" type="method" name="addKnownSchemaLocation" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="137" type="stmt" count="1"/>
       <line num="147" type="method" name="addKnownNamespaceSchemaLocation" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="149" type="stmt" count="1"/>
-      <line num="152" type="method" name="loadAttributeGroup" visibility="private" complexity="3" crap="3" count="104"/>
-      <line num="156" type="stmt" count="104"/>
-      <line num="157" type="stmt" count="104"/>
-      <line num="158" type="stmt" count="104"/>
-      <line num="160" type="stmt" count="104"/>
-      <line num="161" type="stmt" count="104"/>
-      <line num="162" type="stmt" count="104"/>
-      <line num="163" type="stmt" count="104"/>
-      <line num="164" type="stmt" count="104"/>
-      <line num="165" type="stmt" count="104"/>
-      <line num="166" type="stmt" count="104"/>
-      <line num="167" type="stmt" count="104"/>
-      <line num="168" type="stmt" count="104"/>
-      <line num="169" type="stmt" count="104"/>
-      <line num="170" type="stmt" count="104"/>
-      <line num="171" type="stmt" count="104"/>
-      <line num="172" type="stmt" count="104"/>
-      <line num="173" type="stmt" count="104"/>
+      <line num="152" type="method" name="loadAttributeGroup" visibility="private" complexity="3" crap="3" count="113"/>
+      <line num="156" type="stmt" count="113"/>
+      <line num="157" type="stmt" count="113"/>
+      <line num="158" type="stmt" count="113"/>
+      <line num="160" type="stmt" count="113"/>
+      <line num="161" type="stmt" count="113"/>
+      <line num="162" type="stmt" count="113"/>
+      <line num="163" type="stmt" count="113"/>
+      <line num="164" type="stmt" count="113"/>
+      <line num="165" type="stmt" count="113"/>
+      <line num="166" type="stmt" count="113"/>
+      <line num="167" type="stmt" count="113"/>
+      <line num="168" type="stmt" count="113"/>
+      <line num="169" type="stmt" count="113"/>
+      <line num="170" type="stmt" count="113"/>
+      <line num="171" type="stmt" count="113"/>
+      <line num="172" type="stmt" count="113"/>
+      <line num="173" type="stmt" count="113"/>
       <line num="174" type="stmt" count="1"/>
       <line num="175" type="stmt" count="1"/>
       <line num="176" type="stmt" count="1"/>
@@ -677,288 +677,285 @@
       <line num="178" type="stmt" count="1"/>
       <line num="179" type="stmt" count="1"/>
       <line num="180" type="stmt" count="1"/>
-      <line num="182" type="stmt" count="104"/>
-      <line num="183" type="stmt" count="104"/>
-      <line num="184" type="stmt" count="104"/>
-      <line num="187" type="method" name="getAttributeFromAttributeOrRef" visibility="private" complexity="4" crap="4" count="104"/>
-      <line num="192" type="stmt" count="104"/>
-      <line num="193" type="stmt" count="104"/>
-      <line num="194" type="stmt" count="104"/>
-      <line num="195" type="stmt" count="104"/>
-      <line num="196" type="stmt" count="104"/>
-      <line num="197" type="stmt" count="104"/>
-      <line num="199" type="stmt" count="104"/>
-      <line num="200" type="stmt" count="104"/>
-      <line num="203" type="stmt" count="104"/>
-      <line num="209" type="stmt" count="104"/>
-      <line num="212" type="stmt" count="104"/>
-      <line num="215" type="method" name="createAttribute" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="217" type="stmt" count="104"/>
-      <line num="218" type="stmt" count="104"/>
-      <line num="219" type="stmt" count="104"/>
-      <line num="220" type="stmt" count="104"/>
-      <line num="222" type="stmt" count="104"/>
-      <line num="225" type="method" name="fillAttribute" visibility="private" complexity="6" crap="6.01" count="104"/>
-      <line num="227" type="stmt" count="104"/>
+      <line num="182" type="stmt" count="113"/>
+      <line num="183" type="stmt" count="113"/>
+      <line num="184" type="stmt" count="113"/>
+      <line num="187" type="method" name="getAttributeFromAttributeOrRef" visibility="private" complexity="4" crap="4.01" count="113"/>
+      <line num="192" type="stmt" count="113"/>
+      <line num="193" type="stmt" count="113"/>
+      <line num="194" type="stmt" count="113"/>
+      <line num="195" type="stmt" count="113"/>
+      <line num="196" type="stmt" count="113"/>
+      <line num="197" type="stmt" count="113"/>
+      <line num="199" type="stmt" count="113"/>
+      <line num="200" type="stmt" count="113"/>
+      <line num="203" type="stmt" count="0"/>
+      <line num="209" type="stmt" count="113"/>
+      <line num="212" type="stmt" count="113"/>
+      <line num="215" type="method" name="createAttribute" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="217" type="stmt" count="113"/>
+      <line num="218" type="stmt" count="113"/>
+      <line num="219" type="stmt" count="113"/>
+      <line num="220" type="stmt" count="113"/>
+      <line num="222" type="stmt" count="113"/>
+      <line num="225" type="method" name="fillAttribute" visibility="private" complexity="6" crap="6.01" count="113"/>
+      <line num="227" type="stmt" count="113"/>
       <line num="228" type="stmt" count="0"/>
-      <line num="230" type="stmt" count="104"/>
-      <line num="231" type="stmt" count="104"/>
-      <line num="233" type="stmt" count="104"/>
+      <line num="230" type="stmt" count="113"/>
+      <line num="231" type="stmt" count="113"/>
+      <line num="233" type="stmt" count="113"/>
       <line num="234" type="stmt" count="1"/>
-      <line num="237" type="stmt" count="104"/>
-      <line num="238" type="stmt" count="104"/>
+      <line num="237" type="stmt" count="113"/>
+      <line num="238" type="stmt" count="113"/>
       <line num="239" type="stmt" count="2"/>
-      <line num="240" type="stmt" count="104"/>
-      <line num="241" type="stmt" count="104"/>
-      <line num="243" type="stmt" count="104"/>
-      <line num="244" type="stmt" count="104"/>
-      <line num="247" type="stmt" count="104"/>
-      <line num="253" type="method" name="loadCustomAttributesForElement" visibility="private" complexity="4" crap="4" count="104"/>
-      <line num="255" type="stmt" count="104"/>
-      <line num="256" type="stmt" count="104"/>
-      <line num="257" type="stmt" count="104"/>
+      <line num="240" type="stmt" count="113"/>
+      <line num="241" type="stmt" count="113"/>
+      <line num="243" type="stmt" count="113"/>
+      <line num="244" type="stmt" count="113"/>
+      <line num="247" type="stmt" count="113"/>
+      <line num="253" type="method" name="loadCustomAttributesForElement" visibility="private" complexity="4" crap="4" count="113"/>
+      <line num="255" type="stmt" count="113"/>
+      <line num="256" type="stmt" count="113"/>
+      <line num="257" type="stmt" count="113"/>
       <line num="258" type="stmt" count="5"/>
       <line num="259" type="stmt" count="5"/>
       <line num="260" type="stmt" count="5"/>
       <line num="261" type="stmt" count="5"/>
       <line num="262" type="stmt" count="5"/>
-      <line num="266" type="stmt" count="104"/>
-      <line num="269" type="method" name="loadAttributeOrElementDef" visibility="private" complexity="2" crap="2" count="104"/>
-      <line num="275" type="stmt" count="104"/>
-      <line num="276" type="stmt" count="104"/>
-      <line num="277" type="stmt" count="104"/>
-      <line num="278" type="stmt" count="104"/>
-      <line num="279" type="stmt" count="104"/>
-      <line num="280" type="stmt" count="104"/>
-      <line num="282" type="stmt" count="104"/>
-      <line num="283" type="stmt" count="104"/>
-      <line num="284" type="stmt" count="104"/>
-      <line num="285" type="stmt" count="104"/>
-      <line num="288" type="stmt" count="104"/>
-      <line num="289" type="stmt" count="104"/>
-      <line num="290" type="stmt" count="104"/>
-      <line num="293" type="method" name="loadElementDef" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="295" type="stmt" count="104"/>
-      <line num="298" type="method" name="loadAttributeDef" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="300" type="stmt" count="104"/>
-      <line num="303" type="method" name="getDocumentation" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="305" type="stmt" count="104"/>
-      <line num="311" type="method" name="schemaNode" visibility="private" complexity="11" crap="11.02" count="104"/>
-      <line num="313" type="stmt" count="104"/>
-      <line num="314" type="stmt" count="104"/>
-      <line num="316" type="stmt" count="104"/>
-      <line num="317" type="stmt" count="104"/>
-      <line num="318" type="stmt" count="104"/>
-      <line num="319" type="stmt" count="104"/>
-      <line num="321" type="stmt" count="104"/>
-      <line num="322" type="stmt" count="104"/>
-      <line num="323" type="stmt" count="104"/>
-      <line num="324" type="stmt" count="104"/>
-      <line num="325" type="stmt" count="104"/>
-      <line num="326" type="stmt" count="104"/>
-      <line num="327" type="stmt" count="104"/>
-      <line num="328" type="stmt" count="104"/>
-      <line num="329" type="stmt" count="104"/>
-      <line num="330" type="stmt" count="104"/>
-      <line num="331" type="stmt" count="104"/>
-      <line num="332" type="stmt" count="104"/>
-      <line num="333" type="stmt" count="104"/>
-      <line num="334" type="stmt" count="104"/>
-      <line num="335" type="stmt" count="104"/>
-      <line num="336" type="stmt" count="104"/>
-      <line num="337" type="stmt" count="104"/>
-      <line num="338" type="stmt" count="104"/>
+      <line num="266" type="stmt" count="113"/>
+      <line num="269" type="method" name="loadAttributeOrElementDef" visibility="private" complexity="2" crap="2" count="113"/>
+      <line num="275" type="stmt" count="113"/>
+      <line num="276" type="stmt" count="113"/>
+      <line num="277" type="stmt" count="113"/>
+      <line num="278" type="stmt" count="113"/>
+      <line num="279" type="stmt" count="113"/>
+      <line num="280" type="stmt" count="113"/>
+      <line num="282" type="stmt" count="113"/>
+      <line num="283" type="stmt" count="113"/>
+      <line num="284" type="stmt" count="113"/>
+      <line num="285" type="stmt" count="113"/>
+      <line num="288" type="stmt" count="113"/>
+      <line num="289" type="stmt" count="113"/>
+      <line num="290" type="stmt" count="113"/>
+      <line num="293" type="method" name="loadElementDef" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="295" type="stmt" count="113"/>
+      <line num="298" type="method" name="loadAttributeDef" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="300" type="stmt" count="113"/>
+      <line num="303" type="method" name="getDocumentation" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="305" type="stmt" count="113"/>
+      <line num="311" type="method" name="schemaNode" visibility="private" complexity="11" crap="11.02" count="113"/>
+      <line num="313" type="stmt" count="113"/>
+      <line num="314" type="stmt" count="113"/>
+      <line num="316" type="stmt" count="113"/>
+      <line num="317" type="stmt" count="113"/>
+      <line num="318" type="stmt" count="113"/>
+      <line num="319" type="stmt" count="113"/>
+      <line num="321" type="stmt" count="113"/>
+      <line num="322" type="stmt" count="113"/>
+      <line num="323" type="stmt" count="113"/>
+      <line num="324" type="stmt" count="113"/>
+      <line num="325" type="stmt" count="113"/>
+      <line num="326" type="stmt" count="113"/>
+      <line num="327" type="stmt" count="113"/>
+      <line num="328" type="stmt" count="113"/>
+      <line num="329" type="stmt" count="113"/>
+      <line num="330" type="stmt" count="113"/>
+      <line num="331" type="stmt" count="113"/>
+      <line num="332" type="stmt" count="113"/>
+      <line num="333" type="stmt" count="113"/>
+      <line num="334" type="stmt" count="113"/>
+      <line num="335" type="stmt" count="113"/>
+      <line num="336" type="stmt" count="113"/>
+      <line num="337" type="stmt" count="113"/>
+      <line num="338" type="stmt" count="113"/>
       <line num="339" type="stmt" count="0"/>
       <line num="340" type="stmt" count="0"/>
-      <line num="341" type="stmt" count="104"/>
-      <line num="342" type="stmt" count="104"/>
-      <line num="343" type="stmt" count="104"/>
-      <line num="344" type="stmt" count="104"/>
-      <line num="345" type="stmt" count="104"/>
-      <line num="346" type="stmt" count="104"/>
-      <line num="349" type="stmt" count="104"/>
-      <line num="350" type="stmt" count="104"/>
-      <line num="352" type="stmt" count="104"/>
-      <line num="353" type="stmt" count="104"/>
-      <line num="355" type="stmt" count="104"/>
-      <line num="358" type="method" name="createGroupRef" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="360" type="stmt" count="104"/>
-      <line num="361" type="stmt" count="104"/>
-      <line num="363" type="stmt" count="104"/>
-      <line num="364" type="stmt" count="104"/>
-      <line num="366" type="stmt" count="104"/>
-      <line num="369" type="method" name="maybeSetMax" visibility="private" complexity="3" crap="3" count="104"/>
-      <line num="371" type="stmt" count="104"/>
-      <line num="372" type="stmt" count="104"/>
-      <line num="376" type="method" name="maybeSetMin" visibility="private" complexity="4" crap="4" count="104"/>
-      <line num="378" type="stmt" count="104"/>
-      <line num="379" type="stmt" count="104"/>
-      <line num="380" type="stmt" count="104"/>
+      <line num="341" type="stmt" count="113"/>
+      <line num="342" type="stmt" count="113"/>
+      <line num="343" type="stmt" count="113"/>
+      <line num="344" type="stmt" count="113"/>
+      <line num="345" type="stmt" count="113"/>
+      <line num="346" type="stmt" count="113"/>
+      <line num="349" type="stmt" count="113"/>
+      <line num="350" type="stmt" count="113"/>
+      <line num="352" type="stmt" count="113"/>
+      <line num="353" type="stmt" count="113"/>
+      <line num="355" type="stmt" count="113"/>
+      <line num="358" type="method" name="createGroupRef" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="360" type="stmt" count="113"/>
+      <line num="361" type="stmt" count="113"/>
+      <line num="363" type="stmt" count="113"/>
+      <line num="364" type="stmt" count="113"/>
+      <line num="366" type="stmt" count="113"/>
+      <line num="369" type="method" name="maybeSetMax" visibility="private" complexity="3" crap="3" count="113"/>
+      <line num="371" type="stmt" count="113"/>
+      <line num="372" type="stmt" count="113"/>
+      <line num="376" type="method" name="maybeSetMin" visibility="private" complexity="4" crap="4" count="113"/>
+      <line num="378" type="stmt" count="113"/>
+      <line num="379" type="stmt" count="113"/>
+      <line num="380" type="stmt" count="113"/>
       <line num="381" type="stmt" count="8"/>
-      <line num="386" type="method" name="maybeSetFixed" visibility="private" complexity="2" crap="2.50" count="104"/>
-      <line num="388" type="stmt" count="104"/>
+      <line num="386" type="method" name="maybeSetFixed" visibility="private" complexity="2" crap="2.50" count="113"/>
+      <line num="388" type="stmt" count="113"/>
       <line num="389" type="stmt" count="0"/>
-      <line num="393" type="method" name="maybeSetDefault" visibility="private" complexity="2" crap="2" count="104"/>
-      <line num="395" type="stmt" count="104"/>
+      <line num="393" type="method" name="maybeSetDefault" visibility="private" complexity="2" crap="2" count="113"/>
+      <line num="395" type="stmt" count="113"/>
       <line num="396" type="stmt" count="1"/>
-      <line num="400" type="method" name="maybeSetAbstract" visibility="private" complexity="2" crap="2" count="104"/>
-      <line num="402" type="stmt" count="104"/>
-      <line num="403" type="stmt" count="104"/>
-      <line num="407" type="method" name="loadSequence" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="409" type="stmt" count="104"/>
-      <line num="410" type="stmt" count="104"/>
-      <line num="412" type="stmt" count="104"/>
-      <line num="413" type="stmt" count="104"/>
-      <line num="414" type="stmt" count="104"/>
-      <line num="415" type="stmt" count="104"/>
-      <line num="416" type="stmt" count="104"/>
-      <line num="417" type="stmt" count="104"/>
-      <line num="418" type="stmt" count="104"/>
-      <line num="419" type="stmt" count="104"/>
-      <line num="420" type="stmt" count="104"/>
-      <line num="421" type="stmt" count="104"/>
-      <line num="422" type="stmt" count="104"/>
-      <line num="423" type="stmt" count="104"/>
-      <line num="426" type="method" name="loadMinFromNode" visibility="private" complexity="3" crap="3" count="104"/>
-      <line num="428" type="stmt" count="104"/>
-      <line num="429" type="stmt" count="104"/>
-      <line num="432" type="stmt" count="104"/>
-      <line num="435" type="stmt" count="104"/>
-      <line num="438" type="method" name="loadMaxFromNode" visibility="private" complexity="6" crap="6.04" count="104"/>
-      <line num="440" type="stmt" count="104"/>
-      <line num="442" type="stmt" count="104"/>
-      <line num="443" type="stmt" count="104"/>
-      <line num="446" type="stmt" count="104"/>
-      <line num="447" type="stmt" count="6"/>
-      <line num="449" type="stmt" count="6"/>
+      <line num="400" type="method" name="maybeSetAbstract" visibility="private" complexity="2" crap="2" count="113"/>
+      <line num="402" type="stmt" count="113"/>
+      <line num="403" type="stmt" count="113"/>
+      <line num="407" type="method" name="loadSequence" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="409" type="stmt" count="113"/>
+      <line num="410" type="stmt" count="113"/>
+      <line num="412" type="stmt" count="113"/>
+      <line num="413" type="stmt" count="113"/>
+      <line num="414" type="stmt" count="113"/>
+      <line num="415" type="stmt" count="113"/>
+      <line num="416" type="stmt" count="113"/>
+      <line num="417" type="stmt" count="113"/>
+      <line num="418" type="stmt" count="113"/>
+      <line num="419" type="stmt" count="113"/>
+      <line num="420" type="stmt" count="113"/>
+      <line num="421" type="stmt" count="113"/>
+      <line num="422" type="stmt" count="113"/>
+      <line num="423" type="stmt" count="113"/>
+      <line num="426" type="method" name="loadMinFromNode" visibility="private" complexity="3" crap="3" count="113"/>
+      <line num="428" type="stmt" count="113"/>
+      <line num="429" type="stmt" count="113"/>
+      <line num="432" type="stmt" count="113"/>
+      <line num="435" type="stmt" count="113"/>
+      <line num="438" type="method" name="loadMaxFromNode" visibility="private" complexity="5" crap="5.03" count="113"/>
+      <line num="440" type="stmt" count="113"/>
+      <line num="442" type="stmt" count="113"/>
+      <line num="443" type="stmt" count="113"/>
+      <line num="446" type="stmt" count="113"/>
+      <line num="447" type="stmt" count="113"/>
+      <line num="449" type="stmt" count="113"/>
       <line num="450" type="stmt" count="0"/>
-      <line num="453" type="stmt" count="6"/>
-      <line num="454" type="stmt" count="5"/>
-      <line num="458" type="stmt" count="104"/>
-      <line num="461" type="method" name="loadSequenceChildNode" visibility="private" complexity="8" crap="8" count="104"/>
-      <line num="468" type="stmt" count="104"/>
-      <line num="469" type="stmt" count="104"/>
-      <line num="470" type="stmt" count="104"/>
-      <line num="471" type="stmt" count="104"/>
-      <line num="472" type="stmt" count="104"/>
-      <line num="474" type="stmt" count="104"/>
-      <line num="475" type="stmt" count="104"/>
-      <line num="477" type="stmt" count="104"/>
-      <line num="478" type="stmt" count="104"/>
-      <line num="479" type="stmt" count="104"/>
-      <line num="480" type="stmt" count="104"/>
-      <line num="481" type="stmt" count="104"/>
-      <line num="482" type="stmt" count="104"/>
-      <line num="483" type="stmt" count="104"/>
-      <line num="484" type="stmt" count="104"/>
-      <line num="485" type="stmt" count="104"/>
-      <line num="486" type="stmt" count="104"/>
-      <line num="487" type="stmt" count="104"/>
-      <line num="488" type="stmt" count="104"/>
-      <line num="489" type="stmt" count="104"/>
-      <line num="490" type="stmt" count="104"/>
-      <line num="491" type="stmt" count="104"/>
-      <line num="492" type="stmt" count="104"/>
-      <line num="493" type="stmt" count="104"/>
-      <line num="494" type="stmt" count="104"/>
-      <line num="495" type="stmt" count="104"/>
-      <line num="496" type="stmt" count="104"/>
-      <line num="497" type="stmt" count="104"/>
-      <line num="498" type="stmt" count="104"/>
-      <line num="499" type="stmt" count="104"/>
-      <line num="500" type="stmt" count="104"/>
-      <line num="501" type="stmt" count="104"/>
-      <line num="502" type="stmt" count="104"/>
-      <line num="503" type="stmt" count="104"/>
-      <line num="504" type="stmt" count="104"/>
-      <line num="505" type="stmt" count="104"/>
-      <line num="506" type="stmt" count="104"/>
-      <line num="507" type="stmt" count="104"/>
-      <line num="508" type="stmt" count="104"/>
-      <line num="509" type="stmt" count="104"/>
-      <line num="510" type="stmt" count="104"/>
-      <line num="511" type="stmt" count="104"/>
-      <line num="512" type="stmt" count="104"/>
-      <line num="516" type="method" name="loadSequenceChildNodeLoadElement" visibility="private" complexity="6" crap="6" count="104"/>
-      <line num="523" type="stmt" count="104"/>
-      <line num="524" type="stmt" count="104"/>
-      <line num="525" type="stmt" count="104"/>
-      <line num="526" type="stmt" count="104"/>
-      <line num="527" type="stmt" count="104"/>
-      <line num="528" type="stmt" count="104"/>
-      <line num="530" type="stmt" count="104"/>
-      <line num="531" type="stmt" count="104"/>
-      <line num="534" type="stmt" count="104"/>
-      <line num="537" type="stmt" count="104"/>
-      <line num="539" type="stmt" count="104"/>
-      <line num="540" type="stmt" count="104"/>
-      <line num="543" type="stmt" count="104"/>
-      <line num="544" type="stmt" count="4"/>
-      <line num="546" type="stmt" count="104"/>
-      <line num="549" type="method" name="loadSequenceChildNodeLoadAny" visibility="private" complexity="4" crap="4.05" count="104"/>
-      <line num="556" type="stmt" count="104"/>
-      <line num="557" type="stmt" count="104"/>
-      <line num="559" type="stmt" count="104"/>
-      <line num="560" type="stmt" count="104"/>
-      <line num="563" type="stmt" count="104"/>
+      <line num="453" type="stmt" count="113"/>
+      <line num="454" type="stmt" count="113"/>
+      <line num="458" type="stmt" count="113"/>
+      <line num="461" type="method" name="loadSequenceChildNode" visibility="private" complexity="8" crap="8" count="113"/>
+      <line num="468" type="stmt" count="113"/>
+      <line num="469" type="stmt" count="113"/>
+      <line num="470" type="stmt" count="113"/>
+      <line num="471" type="stmt" count="113"/>
+      <line num="472" type="stmt" count="113"/>
+      <line num="474" type="stmt" count="113"/>
+      <line num="475" type="stmt" count="113"/>
+      <line num="477" type="stmt" count="113"/>
+      <line num="478" type="stmt" count="113"/>
+      <line num="479" type="stmt" count="113"/>
+      <line num="480" type="stmt" count="113"/>
+      <line num="481" type="stmt" count="113"/>
+      <line num="482" type="stmt" count="113"/>
+      <line num="483" type="stmt" count="113"/>
+      <line num="484" type="stmt" count="113"/>
+      <line num="485" type="stmt" count="113"/>
+      <line num="486" type="stmt" count="113"/>
+      <line num="487" type="stmt" count="113"/>
+      <line num="488" type="stmt" count="113"/>
+      <line num="489" type="stmt" count="113"/>
+      <line num="490" type="stmt" count="113"/>
+      <line num="491" type="stmt" count="113"/>
+      <line num="492" type="stmt" count="113"/>
+      <line num="493" type="stmt" count="113"/>
+      <line num="494" type="stmt" count="113"/>
+      <line num="495" type="stmt" count="113"/>
+      <line num="496" type="stmt" count="113"/>
+      <line num="497" type="stmt" count="113"/>
+      <line num="498" type="stmt" count="113"/>
+      <line num="499" type="stmt" count="113"/>
+      <line num="500" type="stmt" count="113"/>
+      <line num="501" type="stmt" count="113"/>
+      <line num="502" type="stmt" count="113"/>
+      <line num="503" type="stmt" count="113"/>
+      <line num="504" type="stmt" count="113"/>
+      <line num="505" type="stmt" count="113"/>
+      <line num="506" type="stmt" count="113"/>
+      <line num="507" type="stmt" count="113"/>
+      <line num="508" type="stmt" count="113"/>
+      <line num="509" type="stmt" count="113"/>
+      <line num="510" type="stmt" count="113"/>
+      <line num="511" type="stmt" count="113"/>
+      <line num="512" type="stmt" count="113"/>
+      <line num="516" type="method" name="loadSequenceChildNodeLoadElement" visibility="private" complexity="6" crap="6.01" count="113"/>
+      <line num="523" type="stmt" count="113"/>
+      <line num="524" type="stmt" count="113"/>
+      <line num="525" type="stmt" count="113"/>
+      <line num="526" type="stmt" count="113"/>
+      <line num="527" type="stmt" count="113"/>
+      <line num="528" type="stmt" count="113"/>
+      <line num="530" type="stmt" count="113"/>
+      <line num="531" type="stmt" count="0"/>
+      <line num="534" type="stmt" count="113"/>
+      <line num="537" type="stmt" count="113"/>
+      <line num="539" type="stmt" count="113"/>
+      <line num="540" type="stmt" count="113"/>
+      <line num="543" type="stmt" count="113"/>
+      <line num="544" type="stmt" count="113"/>
+      <line num="546" type="stmt" count="113"/>
+      <line num="549" type="method" name="loadSequenceChildNodeLoadAny" visibility="private" complexity="4" crap="4.05" count="113"/>
+      <line num="556" type="stmt" count="113"/>
+      <line num="557" type="stmt" count="113"/>
+      <line num="559" type="stmt" count="113"/>
+      <line num="560" type="stmt" count="113"/>
+      <line num="563" type="stmt" count="113"/>
       <line num="564" type="stmt" count="0"/>
-      <line num="566" type="stmt" count="104"/>
-      <line num="569" type="method" name="resolveSubstitutionGroup" visibility="private" complexity="2" crap="2" count="104"/>
-      <line num="575" type="stmt" count="104"/>
+      <line num="566" type="stmt" count="113"/>
+      <line num="569" type="method" name="resolveSubstitutionGroup" visibility="private" complexity="2" crap="2" count="113"/>
+      <line num="575" type="stmt" count="113"/>
       <line num="576" type="stmt" count="3"/>
       <line num="577" type="stmt" count="3"/>
       <line num="578" type="stmt" count="3"/>
-      <line num="582" type="method" name="addGroupAsElement" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="588" type="stmt" count="104"/>
-      <line num="589" type="stmt" count="104"/>
-      <line num="590" type="stmt" count="104"/>
-      <line num="591" type="stmt" count="104"/>
-      <line num="592" type="stmt" count="104"/>
-      <line num="594" type="stmt" count="104"/>
-      <line num="595" type="stmt" count="104"/>
-      <line num="598" type="method" name="loadChoiceWithChildren" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="603" type="stmt" count="104"/>
-      <line num="604" type="stmt" count="104"/>
-      <line num="606" type="stmt" count="104"/>
-      <line num="607" type="stmt" count="104"/>
-      <line num="608" type="stmt" count="104"/>
-      <line num="609" type="stmt" count="104"/>
-      <line num="610" type="stmt" count="104"/>
-      <line num="611" type="stmt" count="104"/>
-      <line num="612" type="stmt" count="104"/>
-      <line num="613" type="stmt" count="104"/>
-      <line num="614" type="stmt" count="104"/>
-      <line num="615" type="stmt" count="104"/>
-      <line num="616" type="stmt" count="104"/>
-      <line num="617" type="stmt" count="104"/>
-      <line num="620" type="method" name="loadGroup" visibility="private" complexity="6" crap="6" count="104"/>
-      <line num="622" type="stmt" count="104"/>
-      <line num="623" type="stmt" count="104"/>
-      <line num="624" type="stmt" count="104"/>
-      <line num="626" type="stmt" count="104"/>
-      <line num="627" type="stmt" count="1"/>
-      <line num="630" type="stmt" count="104"/>
-      <line num="632" type="stmt" count="104"/>
-      <line num="633" type="stmt" count="104"/>
-      <line num="634" type="stmt" count="104"/>
-      <line num="635" type="stmt" count="104"/>
-      <line num="636" type="stmt" count="104"/>
-      <line num="637" type="stmt" count="104"/>
-      <line num="638" type="stmt" count="104"/>
-      <line num="639" type="stmt" count="104"/>
-      <line num="640" type="stmt" count="104"/>
-      <line num="641" type="stmt" count="104"/>
-      <line num="642" type="stmt" count="104"/>
-      <line num="644" type="stmt" count="104"/>
-      <line num="645" type="stmt" count="104"/>
-      <line num="646" type="stmt" count="104"/>
-      <line num="649" type="method" name="loadChoice" visibility="private" complexity="1" crap="2" count="0"/>
-      <line num="651" type="stmt" count="0"/>
-      <line num="653" type="stmt" count="0"/>
-      <line num="654" type="stmt" count="0"/>
-      <line num="655" type="stmt" count="0"/>
+      <line num="582" type="method" name="addGroupAsElement" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="588" type="stmt" count="113"/>
+      <line num="589" type="stmt" count="113"/>
+      <line num="590" type="stmt" count="113"/>
+      <line num="591" type="stmt" count="113"/>
+      <line num="592" type="stmt" count="113"/>
+      <line num="594" type="stmt" count="113"/>
+      <line num="595" type="stmt" count="113"/>
+      <line num="598" type="method" name="loadChoiceWithChildren" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="605" type="stmt" count="113"/>
+      <line num="606" type="stmt" count="113"/>
+      <line num="608" type="stmt" count="113"/>
+      <line num="609" type="stmt" count="113"/>
+      <line num="611" type="stmt" count="113"/>
+      <line num="612" type="stmt" count="113"/>
+      <line num="613" type="stmt" count="113"/>
+      <line num="614" type="stmt" count="113"/>
+      <line num="615" type="stmt" count="113"/>
+      <line num="616" type="stmt" count="113"/>
+      <line num="617" type="stmt" count="113"/>
+      <line num="618" type="stmt" count="113"/>
+      <line num="619" type="stmt" count="113"/>
+      <line num="620" type="stmt" count="113"/>
+      <line num="621" type="stmt" count="113"/>
+      <line num="622" type="stmt" count="113"/>
+      <line num="625" type="method" name="loadGroup" visibility="private" complexity="6" crap="6" count="113"/>
+      <line num="627" type="stmt" count="113"/>
+      <line num="628" type="stmt" count="113"/>
+      <line num="629" type="stmt" count="113"/>
+      <line num="631" type="stmt" count="113"/>
+      <line num="632" type="stmt" count="1"/>
+      <line num="635" type="stmt" count="113"/>
+      <line num="637" type="stmt" count="113"/>
+      <line num="638" type="stmt" count="113"/>
+      <line num="639" type="stmt" count="113"/>
+      <line num="640" type="stmt" count="113"/>
+      <line num="641" type="stmt" count="113"/>
+      <line num="642" type="stmt" count="113"/>
+      <line num="643" type="stmt" count="113"/>
+      <line num="644" type="stmt" count="113"/>
+      <line num="645" type="stmt" count="113"/>
+      <line num="646" type="stmt" count="113"/>
+      <line num="647" type="stmt" count="113"/>
+      <line num="649" type="stmt" count="113"/>
+      <line num="650" type="stmt" count="113"/>
+      <line num="651" type="stmt" count="113"/>
+      <line num="654" type="method" name="loadChoice" visibility="private" complexity="1" crap="2" count="0"/>
       <line num="656" type="stmt" count="0"/>
-      <line num="657" type="stmt" count="0"/>
       <line num="658" type="stmt" count="0"/>
       <line num="659" type="stmt" count="0"/>
       <line num="660" type="stmt" count="0"/>
@@ -968,545 +965,550 @@
       <line num="664" type="stmt" count="0"/>
       <line num="665" type="stmt" count="0"/>
       <line num="666" type="stmt" count="0"/>
-      <line num="669" type="method" name="createChoice" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="671" type="stmt" count="104"/>
-      <line num="672" type="stmt" count="104"/>
-      <line num="673" type="stmt" count="104"/>
-      <line num="674" type="stmt" count="104"/>
-      <line num="676" type="stmt" count="104"/>
-      <line num="679" type="method" name="createSequence" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="681" type="stmt" count="104"/>
-      <line num="682" type="stmt" count="104"/>
-      <line num="683" type="stmt" count="104"/>
-      <line num="684" type="stmt" count="104"/>
-      <line num="686" type="stmt" count="104"/>
-      <line num="689" type="method" name="loadComplexType" visibility="private" complexity="6" crap="6" count="104"/>
-      <line num="694" type="stmt" count="104"/>
-      <line num="696" type="stmt" count="104"/>
-      <line num="697" type="stmt" count="104"/>
-      <line num="698" type="stmt" count="104"/>
-      <line num="699" type="stmt" count="104"/>
-      <line num="700" type="stmt" count="1"/>
-      <line num="702" type="stmt" count="104"/>
-      <line num="703" type="stmt" count="5"/>
-      <line num="705" type="stmt" count="104"/>
-      <line num="706" type="stmt" count="104"/>
-      <line num="708" type="stmt" count="104"/>
-      <line num="710" type="stmt" count="104"/>
-      <line num="711" type="stmt" count="104"/>
-      <line num="712" type="stmt" count="104"/>
-      <line num="715" type="stmt" count="104"/>
-      <line num="716" type="stmt" count="104"/>
-      <line num="718" type="stmt" count="104"/>
-      <line num="719" type="stmt" count="104"/>
-      <line num="720" type="stmt" count="104"/>
-      <line num="721" type="stmt" count="104"/>
-      <line num="722" type="stmt" count="104"/>
-      <line num="723" type="stmt" count="104"/>
-      <line num="725" type="stmt" count="104"/>
-      <line num="726" type="stmt" count="104"/>
-      <line num="728" type="stmt" count="104"/>
-      <line num="731" type="method" name="loadComplexTypeFromChildNode" visibility="private" complexity="10" crap="10" count="104"/>
-      <line num="737" type="stmt" count="104"/>
-      <line num="738" type="stmt" count="104"/>
-      <line num="739" type="stmt" count="104"/>
-      <line num="740" type="stmt" count="104"/>
-      <line num="741" type="stmt" count="104"/>
-      <line num="743" type="stmt" count="104"/>
-      <line num="744" type="stmt" count="104"/>
-      <line num="745" type="stmt" count="4"/>
-      <line num="746" type="stmt" count="4"/>
-      <line num="748" type="stmt" count="4"/>
-      <line num="749" type="stmt" count="104"/>
-      <line num="750" type="stmt" count="104"/>
-      <line num="751" type="stmt" count="104"/>
-      <line num="752" type="stmt" count="104"/>
-      <line num="753" type="stmt" count="2"/>
-      <line num="754" type="stmt" count="2"/>
-      <line num="755" type="stmt" count="104"/>
-      <line num="756" type="stmt" count="1"/>
-      <line num="757" type="stmt" count="1"/>
-      <line num="759" type="stmt" count="1"/>
-      <line num="763" type="method" name="loadSimpleType" visibility="private" complexity="5" crap="5" count="104"/>
-      <line num="765" type="stmt" count="104"/>
-      <line num="766" type="stmt" count="104"/>
-      <line num="767" type="stmt" count="104"/>
-      <line num="768" type="stmt" count="104"/>
-      <line num="771" type="stmt" count="104"/>
-      <line num="772" type="stmt" count="104"/>
-      <line num="774" type="stmt" count="104"/>
-      <line num="775" type="stmt" count="104"/>
-      <line num="776" type="stmt" count="104"/>
-      <line num="777" type="stmt" count="104"/>
-      <line num="778" type="stmt" count="104"/>
-      <line num="779" type="stmt" count="104"/>
-      <line num="780" type="stmt" count="104"/>
-      <line num="781" type="stmt" count="104"/>
-      <line num="782" type="stmt" count="104"/>
-      <line num="783" type="stmt" count="104"/>
-      <line num="785" type="stmt" count="104"/>
-      <line num="786" type="stmt" count="104"/>
-      <line num="788" type="stmt" count="104"/>
-      <line num="789" type="stmt" count="104"/>
-      <line num="791" type="stmt" count="104"/>
-      <line num="794" type="method" name="loadList" visibility="private" complexity="2" crap="2" count="104"/>
-      <line num="796" type="stmt" count="104"/>
-      <line num="800" type="stmt" count="104"/>
-      <line num="801" type="stmt" count="104"/>
-      <line num="803" type="stmt" count="104"/>
-      <line num="804" type="stmt" count="104"/>
-      <line num="805" type="stmt" count="104"/>
-      <line num="806" type="stmt" count="104"/>
-      <line num="807" type="stmt" count="104"/>
-      <line num="808" type="stmt" count="104"/>
-      <line num="809" type="stmt" count="104"/>
-      <line num="810" type="stmt" count="104"/>
-      <line num="811" type="stmt" count="104"/>
-      <line num="812" type="stmt" count="104"/>
-      <line num="813" type="stmt" count="104"/>
-      <line num="814" type="stmt" count="104"/>
-      <line num="818" type="method" name="findSomeType" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="823" type="stmt" count="104"/>
-      <line num="824" type="stmt" count="104"/>
-      <line num="825" type="stmt" count="104"/>
-      <line num="826" type="stmt" count="104"/>
-      <line num="827" type="stmt" count="104"/>
-      <line num="830" type="method" name="findSomeTypeFromAttribute" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="835" type="stmt" count="104"/>
-      <line num="836" type="stmt" count="104"/>
-      <line num="837" type="stmt" count="104"/>
-      <line num="838" type="stmt" count="104"/>
-      <line num="839" type="stmt" count="104"/>
-      <line num="842" type="method" name="loadUnion" visibility="private" complexity="3" crap="3" count="104"/>
-      <line num="844" type="stmt" count="104"/>
-      <line num="845" type="stmt" count="104"/>
-      <line num="846" type="stmt" count="104"/>
-      <line num="850" type="stmt" count="104"/>
-      <line num="851" type="stmt" count="104"/>
-      <line num="854" type="stmt" count="104"/>
-      <line num="855" type="stmt" count="104"/>
-      <line num="856" type="stmt" count="104"/>
-      <line num="857" type="stmt" count="104"/>
-      <line num="858" type="stmt" count="104"/>
-      <line num="859" type="stmt" count="104"/>
-      <line num="860" type="stmt" count="104"/>
-      <line num="861" type="stmt" count="104"/>
-      <line num="862" type="stmt" count="104"/>
-      <line num="863" type="stmt" count="104"/>
-      <line num="864" type="stmt" count="104"/>
-      <line num="865" type="stmt" count="104"/>
-      <line num="868" type="method" name="fillTypeNode" visibility="private" complexity="9" crap="9" count="104"/>
-      <line num="870" type="stmt" count="104"/>
-      <line num="871" type="stmt" count="104"/>
-      <line num="873" type="stmt" count="104"/>
-      <line num="874" type="stmt" count="104"/>
-      <line num="875" type="stmt" count="104"/>
-      <line num="879" type="stmt" count="104"/>
-      <line num="880" type="stmt" count="104"/>
-      <line num="881" type="stmt" count="104"/>
-      <line num="882" type="stmt" count="104"/>
-      <line num="883" type="stmt" count="104"/>
-      <line num="884" type="stmt" count="104"/>
-      <line num="885" type="stmt" count="104"/>
-      <line num="886" type="stmt" count="104"/>
-      <line num="887" type="stmt" count="104"/>
-      <line num="888" type="stmt" count="104"/>
-      <line num="890" type="stmt" count="104"/>
-      <line num="891" type="stmt" count="104"/>
-      <line num="892" type="stmt" count="104"/>
-      <line num="893" type="stmt" count="104"/>
-      <line num="894" type="stmt" count="104"/>
-      <line num="896" type="stmt" count="104"/>
-      <line num="897" type="stmt" count="104"/>
-      <line num="900" type="method" name="loadExtension" visibility="private" complexity="2" crap="2" count="104"/>
-      <line num="902" type="stmt" count="104"/>
-      <line num="903" type="stmt" count="104"/>
-      <line num="905" type="stmt" count="104"/>
-      <line num="906" type="stmt" count="104"/>
-      <line num="908" type="stmt" count="104"/>
-      <line num="911" type="method" name="findAndSetSomeBase" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="916" type="stmt" count="104"/>
-      <line num="917" type="stmt" count="104"/>
-      <line num="920" type="method" name="loadExtensionChildNodes" visibility="private" complexity="5" crap="5" count="104"/>
-      <line num="924" type="stmt" count="104"/>
-      <line num="925" type="stmt" count="104"/>
-      <line num="926" type="stmt" count="104"/>
-      <line num="927" type="stmt" count="104"/>
-      <line num="928" type="stmt" count="104"/>
-      <line num="929" type="stmt" count="104"/>
-      <line num="930" type="stmt" count="104"/>
-      <line num="931" type="stmt" count="104"/>
-      <line num="932" type="stmt" count="104"/>
-      <line num="934" type="stmt" count="104"/>
-      <line num="936" type="stmt" count="104"/>
-      <line num="937" type="stmt" count="104"/>
-      <line num="938" type="stmt" count="104"/>
-      <line num="941" type="method" name="loadChildAttributesAndAttributeGroups" visibility="private" complexity="3" crap="3" count="104"/>
-      <line num="946" type="stmt" count="104"/>
-      <line num="947" type="stmt" count="104"/>
-      <line num="948" type="stmt" count="104"/>
-      <line num="949" type="stmt" count="104"/>
-      <line num="950" type="stmt" count="104"/>
-      <line num="951" type="stmt" count="104"/>
-      <line num="952" type="stmt" count="104"/>
-      <line num="953" type="stmt" count="104"/>
-      <line num="954" type="stmt" count="104"/>
-      <line num="955" type="stmt" count="104"/>
-      <line num="956" type="stmt" count="104"/>
-      <line num="957" type="stmt" count="104"/>
-      <line num="958" type="stmt" count="104"/>
-      <line num="959" type="stmt" count="104"/>
-      <line num="960" type="stmt" count="104"/>
-      <line num="961" type="stmt" count="104"/>
-      <line num="962" type="stmt" count="104"/>
-      <line num="966" type="method" name="loadRestriction" visibility="private" complexity="2" crap="2" count="104"/>
-      <line num="968" type="stmt" count="104"/>
-      <line num="969" type="stmt" count="104"/>
-      <line num="970" type="stmt" count="104"/>
-      <line num="971" type="stmt" count="104"/>
-      <line num="973" type="stmt" count="104"/>
-      <line num="974" type="stmt" count="104"/>
-      <line num="975" type="stmt" count="104"/>
-      <line num="976" type="stmt" count="104"/>
-      <line num="977" type="stmt" count="104"/>
-      <line num="978" type="stmt" count="104"/>
-      <line num="979" type="stmt" count="104"/>
-      <line num="980" type="stmt" count="104"/>
-      <line num="981" type="stmt" count="104"/>
-      <line num="982" type="stmt" count="104"/>
-      <line num="983" type="stmt" count="104"/>
-      <line num="984" type="stmt" count="104"/>
-      <line num="985" type="stmt" count="104"/>
-      <line num="986" type="stmt" count="104"/>
-      <line num="987" type="stmt" count="104"/>
-      <line num="988" type="stmt" count="104"/>
-      <line num="989" type="stmt" count="104"/>
-      <line num="990" type="stmt" count="104"/>
-      <line num="992" type="stmt" count="104"/>
-      <line num="995" type="method" name="loadRestrictionChildNodes" visibility="private" complexity="4" crap="4" count="104"/>
-      <line num="1000" type="stmt" count="104"/>
-      <line num="1001" type="stmt" count="104"/>
-      <line num="1002" type="stmt" count="104"/>
-      <line num="1003" type="stmt" count="104"/>
-      <line num="1004" type="stmt" count="104"/>
-      <line num="1007" type="stmt" count="104"/>
-      <line num="1008" type="stmt" count="104"/>
-      <line num="1011" type="stmt" count="104"/>
-      <line num="1012" type="stmt" count="104"/>
-      <line num="1013" type="stmt" count="104"/>
-      <line num="1014" type="stmt" count="104"/>
-      <line num="1015" type="stmt" count="104"/>
-      <line num="1016" type="stmt" count="104"/>
-      <line num="1017" type="stmt" count="104"/>
-      <line num="1018" type="stmt" count="104"/>
-      <line num="1020" type="stmt" count="104"/>
-      <line num="1021" type="stmt" count="104"/>
-      <line num="1027" type="method" name="splitParts" visibility="private" complexity="2" crap="2" count="104"/>
-      <line num="1029" type="stmt" count="104"/>
-      <line num="1030" type="stmt" count="104"/>
-      <line num="1031" type="stmt" count="104"/>
-      <line num="1032" type="stmt" count="104"/>
-      <line num="1038" type="stmt" count="104"/>
-      <line num="1040" type="stmt" count="104"/>
-      <line num="1041" type="stmt" count="104"/>
-      <line num="1042" type="stmt" count="104"/>
-      <line num="1043" type="stmt" count="104"/>
-      <line num="1044" type="stmt" count="104"/>
-      <line num="1047" type="method" name="findAttributeItem" visibility="private" complexity="3" crap="3.33" count="104"/>
-      <line num="1049" type="stmt" count="104"/>
-      <line num="1054" type="stmt" count="104"/>
-      <line num="1060" type="stmt" count="104"/>
-      <line num="1062" type="stmt" count="104"/>
-      <line num="1063" type="stmt" count="0"/>
-      <line num="1064" type="stmt" count="0"/>
-      <line num="1068" type="method" name="findAttributeGroup" visibility="private" complexity="3" crap="3.33" count="104"/>
-      <line num="1070" type="stmt" count="104"/>
-      <line num="1075" type="stmt" count="104"/>
-      <line num="1081" type="stmt" count="104"/>
-      <line num="1083" type="stmt" count="104"/>
-      <line num="1084" type="stmt" count="0"/>
+      <line num="667" type="stmt" count="0"/>
+      <line num="668" type="stmt" count="0"/>
+      <line num="669" type="stmt" count="0"/>
+      <line num="670" type="stmt" count="0"/>
+      <line num="671" type="stmt" count="0"/>
+      <line num="674" type="method" name="createChoice" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="676" type="stmt" count="113"/>
+      <line num="677" type="stmt" count="113"/>
+      <line num="678" type="stmt" count="113"/>
+      <line num="679" type="stmt" count="113"/>
+      <line num="681" type="stmt" count="113"/>
+      <line num="684" type="method" name="createSequence" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="686" type="stmt" count="113"/>
+      <line num="687" type="stmt" count="113"/>
+      <line num="688" type="stmt" count="113"/>
+      <line num="689" type="stmt" count="113"/>
+      <line num="691" type="stmt" count="113"/>
+      <line num="694" type="method" name="loadComplexType" visibility="private" complexity="6" crap="6" count="113"/>
+      <line num="699" type="stmt" count="113"/>
+      <line num="701" type="stmt" count="113"/>
+      <line num="702" type="stmt" count="113"/>
+      <line num="703" type="stmt" count="113"/>
+      <line num="704" type="stmt" count="113"/>
+      <line num="705" type="stmt" count="1"/>
+      <line num="707" type="stmt" count="113"/>
+      <line num="708" type="stmt" count="5"/>
+      <line num="710" type="stmt" count="113"/>
+      <line num="711" type="stmt" count="113"/>
+      <line num="713" type="stmt" count="113"/>
+      <line num="715" type="stmt" count="113"/>
+      <line num="716" type="stmt" count="113"/>
+      <line num="717" type="stmt" count="113"/>
+      <line num="720" type="stmt" count="113"/>
+      <line num="721" type="stmt" count="113"/>
+      <line num="723" type="stmt" count="113"/>
+      <line num="724" type="stmt" count="113"/>
+      <line num="725" type="stmt" count="113"/>
+      <line num="726" type="stmt" count="113"/>
+      <line num="727" type="stmt" count="113"/>
+      <line num="728" type="stmt" count="113"/>
+      <line num="730" type="stmt" count="113"/>
+      <line num="731" type="stmt" count="113"/>
+      <line num="733" type="stmt" count="113"/>
+      <line num="736" type="method" name="loadComplexTypeFromChildNode" visibility="private" complexity="10" crap="10" count="113"/>
+      <line num="742" type="stmt" count="113"/>
+      <line num="743" type="stmt" count="113"/>
+      <line num="744" type="stmt" count="113"/>
+      <line num="745" type="stmt" count="113"/>
+      <line num="746" type="stmt" count="113"/>
+      <line num="748" type="stmt" count="113"/>
+      <line num="749" type="stmt" count="113"/>
+      <line num="750" type="stmt" count="4"/>
+      <line num="751" type="stmt" count="4"/>
+      <line num="753" type="stmt" count="4"/>
+      <line num="754" type="stmt" count="113"/>
+      <line num="755" type="stmt" count="113"/>
+      <line num="756" type="stmt" count="113"/>
+      <line num="757" type="stmt" count="113"/>
+      <line num="758" type="stmt" count="2"/>
+      <line num="759" type="stmt" count="2"/>
+      <line num="760" type="stmt" count="113"/>
+      <line num="761" type="stmt" count="3"/>
+      <line num="762" type="stmt" count="3"/>
+      <line num="764" type="stmt" count="2"/>
+      <line num="768" type="method" name="loadSimpleType" visibility="private" complexity="5" crap="5" count="113"/>
+      <line num="770" type="stmt" count="113"/>
+      <line num="771" type="stmt" count="113"/>
+      <line num="772" type="stmt" count="113"/>
+      <line num="773" type="stmt" count="113"/>
+      <line num="776" type="stmt" count="113"/>
+      <line num="777" type="stmt" count="113"/>
+      <line num="779" type="stmt" count="113"/>
+      <line num="780" type="stmt" count="113"/>
+      <line num="781" type="stmt" count="113"/>
+      <line num="782" type="stmt" count="113"/>
+      <line num="783" type="stmt" count="113"/>
+      <line num="784" type="stmt" count="113"/>
+      <line num="785" type="stmt" count="113"/>
+      <line num="786" type="stmt" count="113"/>
+      <line num="787" type="stmt" count="113"/>
+      <line num="788" type="stmt" count="113"/>
+      <line num="790" type="stmt" count="113"/>
+      <line num="791" type="stmt" count="113"/>
+      <line num="793" type="stmt" count="113"/>
+      <line num="794" type="stmt" count="113"/>
+      <line num="796" type="stmt" count="113"/>
+      <line num="799" type="method" name="loadList" visibility="private" complexity="2" crap="2" count="113"/>
+      <line num="801" type="stmt" count="113"/>
+      <line num="805" type="stmt" count="113"/>
+      <line num="806" type="stmt" count="113"/>
+      <line num="808" type="stmt" count="113"/>
+      <line num="809" type="stmt" count="113"/>
+      <line num="810" type="stmt" count="113"/>
+      <line num="811" type="stmt" count="113"/>
+      <line num="812" type="stmt" count="113"/>
+      <line num="813" type="stmt" count="113"/>
+      <line num="814" type="stmt" count="113"/>
+      <line num="815" type="stmt" count="113"/>
+      <line num="816" type="stmt" count="113"/>
+      <line num="817" type="stmt" count="113"/>
+      <line num="818" type="stmt" count="113"/>
+      <line num="819" type="stmt" count="113"/>
+      <line num="823" type="method" name="findSomeType" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="828" type="stmt" count="113"/>
+      <line num="829" type="stmt" count="113"/>
+      <line num="830" type="stmt" count="113"/>
+      <line num="831" type="stmt" count="113"/>
+      <line num="832" type="stmt" count="113"/>
+      <line num="835" type="method" name="findSomeTypeFromAttribute" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="840" type="stmt" count="113"/>
+      <line num="841" type="stmt" count="113"/>
+      <line num="842" type="stmt" count="113"/>
+      <line num="843" type="stmt" count="113"/>
+      <line num="844" type="stmt" count="113"/>
+      <line num="847" type="method" name="loadUnion" visibility="private" complexity="3" crap="3" count="113"/>
+      <line num="849" type="stmt" count="113"/>
+      <line num="850" type="stmt" count="113"/>
+      <line num="851" type="stmt" count="113"/>
+      <line num="855" type="stmt" count="113"/>
+      <line num="856" type="stmt" count="113"/>
+      <line num="859" type="stmt" count="113"/>
+      <line num="860" type="stmt" count="113"/>
+      <line num="861" type="stmt" count="113"/>
+      <line num="862" type="stmt" count="113"/>
+      <line num="863" type="stmt" count="113"/>
+      <line num="864" type="stmt" count="113"/>
+      <line num="865" type="stmt" count="113"/>
+      <line num="866" type="stmt" count="113"/>
+      <line num="867" type="stmt" count="113"/>
+      <line num="868" type="stmt" count="113"/>
+      <line num="869" type="stmt" count="113"/>
+      <line num="870" type="stmt" count="113"/>
+      <line num="873" type="method" name="fillTypeNode" visibility="private" complexity="9" crap="9" count="113"/>
+      <line num="875" type="stmt" count="113"/>
+      <line num="876" type="stmt" count="113"/>
+      <line num="878" type="stmt" count="113"/>
+      <line num="879" type="stmt" count="113"/>
+      <line num="880" type="stmt" count="113"/>
+      <line num="884" type="stmt" count="113"/>
+      <line num="885" type="stmt" count="113"/>
+      <line num="886" type="stmt" count="113"/>
+      <line num="887" type="stmt" count="113"/>
+      <line num="888" type="stmt" count="113"/>
+      <line num="889" type="stmt" count="113"/>
+      <line num="890" type="stmt" count="113"/>
+      <line num="891" type="stmt" count="113"/>
+      <line num="892" type="stmt" count="113"/>
+      <line num="893" type="stmt" count="113"/>
+      <line num="895" type="stmt" count="113"/>
+      <line num="896" type="stmt" count="113"/>
+      <line num="897" type="stmt" count="113"/>
+      <line num="898" type="stmt" count="113"/>
+      <line num="899" type="stmt" count="113"/>
+      <line num="901" type="stmt" count="113"/>
+      <line num="902" type="stmt" count="113"/>
+      <line num="905" type="method" name="loadExtension" visibility="private" complexity="2" crap="2" count="113"/>
+      <line num="907" type="stmt" count="113"/>
+      <line num="908" type="stmt" count="113"/>
+      <line num="910" type="stmt" count="113"/>
+      <line num="911" type="stmt" count="113"/>
+      <line num="913" type="stmt" count="113"/>
+      <line num="916" type="method" name="findAndSetSomeBase" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="921" type="stmt" count="113"/>
+      <line num="922" type="stmt" count="113"/>
+      <line num="925" type="method" name="loadExtensionChildNodes" visibility="private" complexity="5" crap="5" count="113"/>
+      <line num="929" type="stmt" count="113"/>
+      <line num="930" type="stmt" count="113"/>
+      <line num="931" type="stmt" count="113"/>
+      <line num="932" type="stmt" count="113"/>
+      <line num="933" type="stmt" count="113"/>
+      <line num="934" type="stmt" count="113"/>
+      <line num="935" type="stmt" count="113"/>
+      <line num="936" type="stmt" count="113"/>
+      <line num="937" type="stmt" count="113"/>
+      <line num="939" type="stmt" count="113"/>
+      <line num="941" type="stmt" count="113"/>
+      <line num="942" type="stmt" count="113"/>
+      <line num="943" type="stmt" count="113"/>
+      <line num="946" type="method" name="loadChildAttributesAndAttributeGroups" visibility="private" complexity="3" crap="3" count="113"/>
+      <line num="951" type="stmt" count="113"/>
+      <line num="952" type="stmt" count="113"/>
+      <line num="953" type="stmt" count="113"/>
+      <line num="954" type="stmt" count="113"/>
+      <line num="955" type="stmt" count="113"/>
+      <line num="956" type="stmt" count="113"/>
+      <line num="957" type="stmt" count="113"/>
+      <line num="958" type="stmt" count="113"/>
+      <line num="959" type="stmt" count="113"/>
+      <line num="960" type="stmt" count="113"/>
+      <line num="961" type="stmt" count="113"/>
+      <line num="962" type="stmt" count="113"/>
+      <line num="963" type="stmt" count="113"/>
+      <line num="964" type="stmt" count="113"/>
+      <line num="965" type="stmt" count="113"/>
+      <line num="966" type="stmt" count="113"/>
+      <line num="967" type="stmt" count="113"/>
+      <line num="971" type="method" name="loadRestriction" visibility="private" complexity="2" crap="2" count="113"/>
+      <line num="973" type="stmt" count="113"/>
+      <line num="974" type="stmt" count="113"/>
+      <line num="975" type="stmt" count="113"/>
+      <line num="976" type="stmt" count="113"/>
+      <line num="978" type="stmt" count="113"/>
+      <line num="979" type="stmt" count="113"/>
+      <line num="980" type="stmt" count="113"/>
+      <line num="981" type="stmt" count="113"/>
+      <line num="982" type="stmt" count="113"/>
+      <line num="983" type="stmt" count="113"/>
+      <line num="984" type="stmt" count="113"/>
+      <line num="985" type="stmt" count="113"/>
+      <line num="986" type="stmt" count="113"/>
+      <line num="987" type="stmt" count="113"/>
+      <line num="988" type="stmt" count="113"/>
+      <line num="989" type="stmt" count="113"/>
+      <line num="990" type="stmt" count="113"/>
+      <line num="991" type="stmt" count="113"/>
+      <line num="992" type="stmt" count="113"/>
+      <line num="993" type="stmt" count="113"/>
+      <line num="994" type="stmt" count="113"/>
+      <line num="995" type="stmt" count="113"/>
+      <line num="997" type="stmt" count="113"/>
+      <line num="1000" type="method" name="loadRestrictionChildNodes" visibility="private" complexity="4" crap="4" count="113"/>
+      <line num="1005" type="stmt" count="113"/>
+      <line num="1006" type="stmt" count="113"/>
+      <line num="1007" type="stmt" count="113"/>
+      <line num="1008" type="stmt" count="113"/>
+      <line num="1009" type="stmt" count="113"/>
+      <line num="1012" type="stmt" count="113"/>
+      <line num="1013" type="stmt" count="113"/>
+      <line num="1016" type="stmt" count="113"/>
+      <line num="1017" type="stmt" count="113"/>
+      <line num="1018" type="stmt" count="113"/>
+      <line num="1019" type="stmt" count="113"/>
+      <line num="1020" type="stmt" count="113"/>
+      <line num="1021" type="stmt" count="113"/>
+      <line num="1022" type="stmt" count="113"/>
+      <line num="1023" type="stmt" count="113"/>
+      <line num="1025" type="stmt" count="113"/>
+      <line num="1026" type="stmt" count="113"/>
+      <line num="1032" type="method" name="splitParts" visibility="private" complexity="4" crap="4" count="113"/>
+      <line num="1034" type="stmt" count="113"/>
+      <line num="1035" type="stmt" count="113"/>
+      <line num="1036" type="stmt" count="113"/>
+      <line num="1037" type="stmt" count="113"/>
+      <line num="1041" type="stmt" count="113"/>
+      <line num="1047" type="stmt" count="113"/>
+      <line num="1048" type="stmt" count="1"/>
+      <line num="1051" type="stmt" count="113"/>
+      <line num="1052" type="stmt" count="113"/>
+      <line num="1053" type="stmt" count="113"/>
+      <line num="1054" type="stmt" count="113"/>
+      <line num="1055" type="stmt" count="113"/>
+      <line num="1058" type="method" name="findAttributeItem" visibility="private" complexity="2" crap="2.26" count="113"/>
+      <line num="1060" type="stmt" count="113"/>
+      <line num="1066" type="stmt" count="113"/>
+      <line num="1068" type="stmt" count="113"/>
+      <line num="1069" type="stmt" count="0"/>
+      <line num="1070" type="stmt" count="0"/>
+      <line num="1074" type="method" name="findAttributeGroup" visibility="private" complexity="2" crap="2.26" count="113"/>
+      <line num="1076" type="stmt" count="113"/>
+      <line num="1082" type="stmt" count="113"/>
+      <line num="1084" type="stmt" count="113"/>
       <line num="1085" type="stmt" count="0"/>
-      <line num="1089" type="method" name="findElement" visibility="private" complexity="3" crap="3.58" count="104"/>
-      <line num="1091" type="stmt" count="104"/>
-      <line num="1096" type="stmt" count="104"/>
-      <line num="1099" type="stmt" count="104"/>
-      <line num="1100" type="stmt" count="0"/>
-      <line num="1101" type="stmt" count="0"/>
-      <line num="1105" type="method" name="findGroup" visibility="private" complexity="3" crap="3.33" count="104"/>
-      <line num="1107" type="stmt" count="104"/>
-      <line num="1112" type="stmt" count="104"/>
-      <line num="1118" type="stmt" count="104"/>
-      <line num="1120" type="stmt" count="104"/>
-      <line num="1121" type="stmt" count="0"/>
-      <line num="1122" type="stmt" count="0"/>
-      <line num="1126" type="method" name="findType" visibility="private" complexity="5" crap="5.01" count="104"/>
-      <line num="1128" type="stmt" count="104"/>
-      <line num="1133" type="stmt" count="104"/>
-      <line num="1135" type="stmt" count="104"/>
-      <line num="1137" type="stmt" count="104"/>
-      <line num="1138" type="stmt" count="1"/>
-      <line num="1139" type="stmt" count="1"/>
-      <line num="1141" type="stmt" count="104"/>
-      <line num="1143" type="stmt" count="104"/>
-      <line num="1144" type="stmt" count="104"/>
-      <line num="1145" type="stmt" count="104"/>
-      <line num="1146" type="stmt" count="104"/>
-      <line num="1150" type="stmt" count="0"/>
-      <line num="1153" type="method" name="fillItem" visibility="private" complexity="5" crap="5" count="104"/>
-      <line num="1155" type="stmt" count="104"/>
-      <line num="1156" type="stmt" count="104"/>
-      <line num="1162" type="stmt" count="104"/>
-      <line num="1163" type="stmt" count="104"/>
-      <line num="1164" type="stmt" count="104"/>
-      <line num="1165" type="stmt" count="104"/>
-      <line num="1167" type="stmt" count="104"/>
-      <line num="1168" type="stmt" count="104"/>
-      <line num="1169" type="stmt" count="104"/>
-      <line num="1170" type="stmt" count="104"/>
-      <line num="1171" type="stmt" count="104"/>
-      <line num="1172" type="stmt" count="104"/>
-      <line num="1173" type="stmt" count="104"/>
-      <line num="1174" type="stmt" count="104"/>
-      <line num="1175" type="stmt" count="104"/>
-      <line num="1177" type="stmt" count="104"/>
-      <line num="1178" type="stmt" count="104"/>
-      <line num="1179" type="stmt" count="104"/>
-      <line num="1180" type="stmt" count="104"/>
-      <line num="1181" type="stmt" count="104"/>
-      <line num="1182" type="stmt" count="104"/>
-      <line num="1183" type="stmt" count="104"/>
-      <line num="1184" type="stmt" count="104"/>
-      <line num="1186" type="stmt" count="104"/>
-      <line num="1187" type="stmt" count="104"/>
-      <line num="1188" type="stmt" count="104"/>
-      <line num="1189" type="stmt" count="104"/>
-      <line num="1191" type="stmt" count="104"/>
-      <line num="1194" type="method" name="fillItemNonLocalType" visibility="private" complexity="2" crap="2" count="104"/>
-      <line num="1196" type="stmt" count="104"/>
-      <line num="1200" type="stmt" count="104"/>
-      <line num="1205" type="stmt" count="104"/>
-      <line num="1206" type="stmt" count="104"/>
-      <line num="1207" type="stmt" count="104"/>
-      <line num="1208" type="stmt" count="104"/>
-      <line num="1209" type="stmt" count="104"/>
-      <line num="1212" type="stmt" count="104"/>
-      <line num="1215" type="method" name="loadImport" visibility="private" complexity="13" crap="13" count="104"/>
-      <line num="1219" type="stmt" count="104"/>
-      <line num="1220" type="stmt" count="104"/>
-      <line num="1221" type="stmt" count="104"/>
-      <line num="1222" type="stmt" count="1"/>
-      <line num="1226" type="stmt" count="104"/>
-      <line num="1227" type="stmt" count="5"/>
-      <line num="1228" type="stmt" count="5"/>
-      <line num="1229" type="stmt" count="5"/>
-      <line num="1230" type="stmt" count="5"/>
-      <line num="1233" type="stmt" count="5"/>
-      <line num="1236" type="stmt" count="104"/>
-      <line num="1237" type="stmt" count="1"/>
-      <line num="1238" type="stmt" count="1"/>
-      <line num="1242" type="stmt" count="104"/>
-      <line num="1243" type="stmt" count="104"/>
-      <line num="1245" type="stmt" count="104"/>
-      <line num="1246" type="stmt" count="104"/>
-      <line num="1248" type="stmt" count="104"/>
-      <line num="1249" type="stmt" count="104"/>
-      <line num="1252" type="stmt" count="3"/>
-      <line num="1255" type="method" name="createOrUseSchemaForNs" visibility="private" complexity="2" crap="2" count="3"/>
-      <line num="1257" type="stmt" count="3"/>
-      <line num="1258" type="stmt" count="2"/>
-      <line num="1259" type="stmt" count="2"/>
-      <line num="1260" type="stmt" count="2"/>
-      <line num="1262" type="stmt" count="1"/>
+      <line num="1086" type="stmt" count="0"/>
+      <line num="1090" type="method" name="findElement" visibility="private" complexity="2" crap="2.50" count="113"/>
+      <line num="1092" type="stmt" count="113"/>
+      <line num="1095" type="stmt" count="113"/>
+      <line num="1096" type="stmt" count="0"/>
+      <line num="1097" type="stmt" count="0"/>
+      <line num="1101" type="method" name="findGroup" visibility="private" complexity="2" crap="2" count="113"/>
+      <line num="1103" type="stmt" count="113"/>
+      <line num="1109" type="stmt" count="113"/>
+      <line num="1111" type="stmt" count="113"/>
+      <line num="1112" type="stmt" count="1"/>
+      <line num="1113" type="stmt" count="1"/>
+      <line num="1117" type="method" name="findType" visibility="private" complexity="4" crap="4.01" count="113"/>
+      <line num="1119" type="stmt" count="113"/>
+      <line num="1121" type="stmt" count="113"/>
+      <line num="1123" type="stmt" count="113"/>
+      <line num="1124" type="stmt" count="1"/>
+      <line num="1125" type="stmt" count="1"/>
+      <line num="1127" type="stmt" count="113"/>
+      <line num="1129" type="stmt" count="113"/>
+      <line num="1130" type="stmt" count="113"/>
+      <line num="1131" type="stmt" count="113"/>
+      <line num="1132" type="stmt" count="113"/>
+      <line num="1136" type="stmt" count="0"/>
+      <line num="1139" type="method" name="fillItem" visibility="private" complexity="5" crap="5" count="113"/>
+      <line num="1141" type="stmt" count="113"/>
+      <line num="1142" type="stmt" count="113"/>
+      <line num="1148" type="stmt" count="113"/>
+      <line num="1149" type="stmt" count="113"/>
+      <line num="1150" type="stmt" count="113"/>
+      <line num="1151" type="stmt" count="113"/>
+      <line num="1153" type="stmt" count="113"/>
+      <line num="1154" type="stmt" count="113"/>
+      <line num="1155" type="stmt" count="113"/>
+      <line num="1156" type="stmt" count="113"/>
+      <line num="1157" type="stmt" count="113"/>
+      <line num="1158" type="stmt" count="113"/>
+      <line num="1159" type="stmt" count="113"/>
+      <line num="1160" type="stmt" count="113"/>
+      <line num="1161" type="stmt" count="113"/>
+      <line num="1163" type="stmt" count="113"/>
+      <line num="1164" type="stmt" count="113"/>
+      <line num="1165" type="stmt" count="113"/>
+      <line num="1166" type="stmt" count="113"/>
+      <line num="1167" type="stmt" count="113"/>
+      <line num="1168" type="stmt" count="113"/>
+      <line num="1169" type="stmt" count="113"/>
+      <line num="1170" type="stmt" count="113"/>
+      <line num="1172" type="stmt" count="113"/>
+      <line num="1173" type="stmt" count="113"/>
+      <line num="1174" type="stmt" count="113"/>
+      <line num="1175" type="stmt" count="113"/>
+      <line num="1177" type="stmt" count="113"/>
+      <line num="1180" type="method" name="fillItemNonLocalType" visibility="private" complexity="3" crap="3" count="113"/>
+      <line num="1182" type="stmt" count="113"/>
+      <line num="1186" type="stmt" count="113"/>
+      <line num="1188" type="stmt" count="113"/>
+      <line num="1189" type="stmt" count="113"/>
+      <line num="1190" type="stmt" count="113"/>
+      <line num="1195" type="stmt" count="113"/>
+      <line num="1196" type="stmt" count="113"/>
+      <line num="1197" type="stmt" count="113"/>
+      <line num="1198" type="stmt" count="113"/>
+      <line num="1199" type="stmt" count="113"/>
+      <line num="1202" type="stmt" count="113"/>
+      <line num="1205" type="method" name="loadImport" visibility="private" complexity="13" crap="13" count="113"/>
+      <line num="1209" type="stmt" count="113"/>
+      <line num="1210" type="stmt" count="113"/>
+      <line num="1211" type="stmt" count="113"/>
+      <line num="1212" type="stmt" count="1"/>
+      <line num="1216" type="stmt" count="113"/>
+      <line num="1217" type="stmt" count="5"/>
+      <line num="1218" type="stmt" count="5"/>
+      <line num="1219" type="stmt" count="5"/>
+      <line num="1220" type="stmt" count="5"/>
+      <line num="1223" type="stmt" count="5"/>
+      <line num="1226" type="stmt" count="113"/>
+      <line num="1227" type="stmt" count="1"/>
+      <line num="1228" type="stmt" count="1"/>
+      <line num="1232" type="stmt" count="113"/>
+      <line num="1233" type="stmt" count="113"/>
+      <line num="1235" type="stmt" count="113"/>
+      <line num="1236" type="stmt" count="113"/>
+      <line num="1238" type="stmt" count="113"/>
+      <line num="1239" type="stmt" count="113"/>
+      <line num="1242" type="stmt" count="3"/>
+      <line num="1245" type="method" name="createOrUseSchemaForNs" visibility="private" complexity="2" crap="2" count="3"/>
+      <line num="1247" type="stmt" count="3"/>
+      <line num="1248" type="stmt" count="2"/>
+      <line num="1249" type="stmt" count="2"/>
+      <line num="1250" type="stmt" count="2"/>
+      <line num="1252" type="stmt" count="1"/>
+      <line num="1255" type="stmt" count="3"/>
+      <line num="1258" type="method" name="loadImportFresh" visibility="private" complexity="2" crap="2" count="3"/>
+      <line num="1263" type="stmt" count="3"/>
+      <line num="1264" type="stmt" count="3"/>
       <line num="1265" type="stmt" count="3"/>
-      <line num="1268" type="method" name="loadImportFresh" visibility="private" complexity="2" crap="2" count="3"/>
+      <line num="1266" type="stmt" count="3"/>
+      <line num="1267" type="stmt" count="3"/>
+      <line num="1269" type="stmt" count="3"/>
+      <line num="1271" type="stmt" count="3"/>
       <line num="1273" type="stmt" count="3"/>
-      <line num="1274" type="stmt" count="3"/>
       <line num="1275" type="stmt" count="3"/>
       <line num="1276" type="stmt" count="3"/>
-      <line num="1277" type="stmt" count="3"/>
-      <line num="1279" type="stmt" count="3"/>
-      <line num="1281" type="stmt" count="3"/>
-      <line num="1283" type="stmt" count="3"/>
-      <line num="1285" type="stmt" count="3"/>
-      <line num="1286" type="stmt" count="3"/>
-      <line num="1288" type="stmt" count="3"/>
-      <line num="1296" type="method" name="getGlobalSchema" visibility="public" complexity="6" crap="6" count="104"/>
-      <line num="1298" type="stmt" count="104"/>
-      <line num="1299" type="stmt" count="104"/>
-      <line num="1300" type="stmt" count="104"/>
-      <line num="1304" type="stmt" count="104"/>
-      <line num="1305" type="stmt" count="104"/>
-      <line num="1306" type="stmt" count="104"/>
-      <line num="1307" type="stmt" count="104"/>
-      <line num="1308" type="stmt" count="104"/>
-      <line num="1309" type="stmt" count="104"/>
-      <line num="1310" type="stmt" count="104"/>
-      <line num="1311" type="stmt" count="104"/>
-      <line num="1313" type="stmt" count="104"/>
-      <line num="1314" type="stmt" count="104"/>
-      <line num="1317" type="stmt" count="104"/>
-      <line num="1318" type="stmt" count="104"/>
-      <line num="1320" type="stmt" count="104"/>
-      <line num="1321" type="stmt" count="104"/>
-      <line num="1322" type="stmt" count="104"/>
-      <line num="1323" type="stmt" count="104"/>
-      <line num="1324" type="stmt" count="104"/>
-      <line num="1325" type="stmt" count="104"/>
-      <line num="1326" type="stmt" count="104"/>
-      <line num="1327" type="stmt" count="104"/>
-      <line num="1332" type="stmt" count="104"/>
-      <line num="1333" type="stmt" count="104"/>
-      <line num="1337" type="stmt" count="104"/>
-      <line num="1338" type="stmt" count="0"/>
-      <line num="1341" type="stmt" count="104"/>
-      <line num="1347" type="method" name="readNodes" visibility="public" complexity="7" crap="7" count="4"/>
+      <line num="1278" type="stmt" count="3"/>
+      <line num="1286" type="method" name="getGlobalSchema" visibility="public" complexity="6" crap="6" count="113"/>
+      <line num="1288" type="stmt" count="113"/>
+      <line num="1289" type="stmt" count="113"/>
+      <line num="1290" type="stmt" count="113"/>
+      <line num="1294" type="stmt" count="113"/>
+      <line num="1295" type="stmt" count="113"/>
+      <line num="1296" type="stmt" count="113"/>
+      <line num="1297" type="stmt" count="113"/>
+      <line num="1298" type="stmt" count="113"/>
+      <line num="1299" type="stmt" count="113"/>
+      <line num="1300" type="stmt" count="113"/>
+      <line num="1301" type="stmt" count="113"/>
+      <line num="1303" type="stmt" count="113"/>
+      <line num="1304" type="stmt" count="113"/>
+      <line num="1307" type="stmt" count="113"/>
+      <line num="1308" type="stmt" count="113"/>
+      <line num="1310" type="stmt" count="113"/>
+      <line num="1311" type="stmt" count="113"/>
+      <line num="1312" type="stmt" count="113"/>
+      <line num="1313" type="stmt" count="113"/>
+      <line num="1314" type="stmt" count="113"/>
+      <line num="1315" type="stmt" count="113"/>
+      <line num="1316" type="stmt" count="113"/>
+      <line num="1317" type="stmt" count="113"/>
+      <line num="1322" type="stmt" count="113"/>
+      <line num="1323" type="stmt" count="113"/>
+      <line num="1327" type="stmt" count="113"/>
+      <line num="1328" type="stmt" count="0"/>
+      <line num="1331" type="stmt" count="113"/>
+      <line num="1337" type="method" name="readNodes" visibility="public" complexity="7" crap="7" count="4"/>
+      <line num="1339" type="stmt" count="4"/>
+      <line num="1340" type="stmt" count="4"/>
+      <line num="1342" type="stmt" count="4"/>
+      <line num="1343" type="stmt" count="4"/>
+      <line num="1346" type="stmt" count="4"/>
+      <line num="1347" type="stmt" count="4"/>
+      <line num="1348" type="stmt" count="4"/>
       <line num="1349" type="stmt" count="4"/>
       <line num="1350" type="stmt" count="4"/>
       <line num="1352" type="stmt" count="4"/>
-      <line num="1353" type="stmt" count="4"/>
+      <line num="1354" type="stmt" count="4"/>
       <line num="1356" type="stmt" count="4"/>
       <line num="1357" type="stmt" count="4"/>
-      <line num="1358" type="stmt" count="4"/>
-      <line num="1359" type="stmt" count="4"/>
-      <line num="1360" type="stmt" count="4"/>
+      <line num="1361" type="stmt" count="4"/>
       <line num="1362" type="stmt" count="4"/>
-      <line num="1364" type="stmt" count="4"/>
-      <line num="1366" type="stmt" count="4"/>
-      <line num="1367" type="stmt" count="4"/>
-      <line num="1371" type="stmt" count="4"/>
-      <line num="1372" type="stmt" count="4"/>
-      <line num="1375" type="stmt" count="4"/>
-      <line num="1378" type="method" name="readNode" visibility="public" complexity="3" crap="3" count="100"/>
-      <line num="1380" type="stmt" count="100"/>
-      <line num="1381" type="stmt" count="100"/>
-      <line num="1383" type="stmt" count="100"/>
-      <line num="1384" type="stmt" count="99"/>
-      <line num="1387" type="stmt" count="100"/>
-      <line num="1389" type="stmt" count="100"/>
-      <line num="1391" type="stmt" count="100"/>
-      <line num="1392" type="stmt" count="94"/>
-      <line num="1395" type="stmt" count="100"/>
-      <line num="1401" type="method" name="readString" visibility="public" complexity="2" crap="2" count="96"/>
-      <line num="1403" type="stmt" count="96"/>
-      <line num="1404" type="stmt" count="96"/>
-      <line num="1405" type="stmt" count="96"/>
-      <line num="1406" type="stmt" count="1"/>
-      <line num="1408" type="stmt" count="95"/>
-      <line num="1409" type="stmt" count="95"/>
-      <line num="1411" type="stmt" count="95"/>
-      <line num="1417" type="method" name="readFile" visibility="public" complexity="1" crap="1" count="5"/>
-      <line num="1419" type="stmt" count="5"/>
-      <line num="1421" type="stmt" count="4"/>
-      <line num="1427" type="method" name="getDOM" visibility="private" complexity="2" crap="2" count="105"/>
-      <line num="1429" type="stmt" count="105"/>
-      <line num="1430" type="stmt" count="105"/>
-      <line num="1431" type="stmt" count="105"/>
-      <line num="1432" type="stmt" count="1"/>
-      <line num="1433" type="stmt" count="1"/>
-      <line num="1435" type="stmt" count="104"/>
-      <line num="1437" type="stmt" count="104"/>
-      <line num="1440" type="method" name="againstDOMNodeList" visibility="private" complexity="3" crap="3" count="104"/>
-      <line num="1442" type="stmt" count="104"/>
-      <line num="1443" type="stmt" count="104"/>
-      <line num="1447" type="stmt" count="104"/>
-      <line num="1449" type="stmt" count="104"/>
-      <line num="1450" type="stmt" count="104"/>
-      <line num="1455" type="method" name="loadTypeWithCallback" visibility="private" complexity="4" crap="4" count="104"/>
-      <line num="1460" type="stmt" count="104"/>
-      <line num="1462" type="stmt" count="104"/>
-      <line num="1463" type="stmt" count="104"/>
-      <line num="1464" type="stmt" count="104"/>
-      <line num="1465" type="stmt" count="104"/>
-      <line num="1466" type="stmt" count="104"/>
-      <line num="1467" type="stmt" count="104"/>
-      <line num="1468" type="stmt" count="104"/>
-      <line num="1471" type="stmt" count="104"/>
-      <line num="1472" type="stmt" count="104"/>
-      <line num="1476" type="method" name="createElement" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="1478" type="stmt" count="104"/>
-      <line num="1479" type="stmt" count="104"/>
-      <line num="1480" type="stmt" count="104"/>
-      <line num="1481" type="stmt" count="104"/>
-      <line num="1483" type="stmt" count="104"/>
-      <line num="1486" type="method" name="fillElement" visibility="private" complexity="7" crap="7" count="104"/>
-      <line num="1488" type="stmt" count="104"/>
-      <line num="1489" type="stmt" count="104"/>
-      <line num="1490" type="stmt" count="104"/>
-      <line num="1491" type="stmt" count="104"/>
-      <line num="1492" type="stmt" count="104"/>
-      <line num="1494" type="stmt" count="104"/>
-      <line num="1495" type="stmt" count="104"/>
-      <line num="1497" type="stmt" count="104"/>
-      <line num="1498" type="stmt" count="104"/>
-      <line num="1501" type="stmt" count="104"/>
-      <line num="1502" type="stmt" count="4"/>
-      <line num="1505" type="stmt" count="104"/>
-      <line num="1506" type="stmt" count="104"/>
-      <line num="1507" type="stmt" count="6"/>
-      <line num="1508" type="stmt" count="104"/>
-      <line num="1509" type="stmt" count="104"/>
-      <line num="1511" type="stmt" count="104"/>
-      <line num="1512" type="stmt" count="104"/>
-      <line num="1513" type="stmt" count="104"/>
-      <line num="1514" type="stmt" count="104"/>
-      <line num="1516" type="stmt" count="104"/>
-      <line num="1520" type="stmt" count="104"/>
-      <line num="1523" type="method" name="createAnyElement" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="1525" type="stmt" count="104"/>
-      <line num="1526" type="stmt" count="104"/>
-      <line num="1528" type="stmt" count="104"/>
-      <line num="1531" type="method" name="fillAnyElement" visibility="private" complexity="4" crap="4" count="104"/>
-      <line num="1533" type="stmt" count="104"/>
-      <line num="1534" type="stmt" count="104"/>
-      <line num="1536" type="stmt" count="104"/>
-      <line num="1537" type="stmt" count="2"/>
-      <line num="1540" type="stmt" count="104"/>
-      <line num="1541" type="stmt" count="3"/>
-      <line num="1544" type="stmt" count="104"/>
-      <line num="1545" type="stmt" count="104"/>
-      <line num="1546" type="stmt" count="104"/>
-      <line num="1547" type="stmt" count="104"/>
-      <line num="1550" type="stmt" count="104"/>
-      <line num="1553" type="method" name="addAttributeFromAttributeOrRef" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="1559" type="stmt" count="104"/>
-      <line num="1560" type="stmt" count="104"/>
-      <line num="1561" type="stmt" count="104"/>
-      <line num="1562" type="stmt" count="104"/>
-      <line num="1563" type="stmt" count="104"/>
-      <line num="1565" type="stmt" count="104"/>
-      <line num="1568" type="method" name="findSomethingLikeAttributeGroup" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="1574" type="stmt" count="104"/>
-      <line num="1575" type="stmt" count="104"/>
-      <line num="1578" type="method" name="setLoadedFile" visibility="private" complexity="1" crap="1" count="104"/>
-      <line num="1580" type="stmt" count="104"/>
-      <line num="1583" type="method" name="setLoadedSchemaFromElement" visibility="private" complexity="2" crap="2" count="104"/>
-      <line num="1585" type="stmt" count="104"/>
-      <line num="1586" type="stmt" count="104"/>
-      <line num="1590" type="method" name="setLoadedSchema" visibility="private" complexity="3" crap="3" count="104"/>
-      <line num="1592" type="stmt" count="104"/>
-      <line num="1593" type="stmt" count="104"/>
-      <line num="1595" type="stmt" count="104"/>
-      <line num="1596" type="stmt" count="104"/>
-      <line num="1600" type="method" name="setSchemaThingsFromNode" visibility="private" complexity="3" crap="3.14" count="104"/>
-      <line num="1605" type="stmt" count="104"/>
-      <line num="1607" type="stmt" count="104"/>
-      <line num="1608" type="stmt" count="104"/>
-      <line num="1609" type="stmt" count="0"/>
-      <line num="1610" type="stmt" count="0"/>
-      <line num="1612" type="stmt" count="104"/>
-      <line num="1613" type="stmt" count="104"/>
-      <line num="1614" type="stmt" count="104"/>
-      <metrics loc="1617" ncloc="1499" classes="1" methods="76" coveredmethods="63" conditionals="0" coveredconditionals="0" statements="783" coveredstatements="750" elements="859" coveredelements="813"/>
+      <line num="1365" type="stmt" count="4"/>
+      <line num="1368" type="method" name="readNode" visibility="public" complexity="3" crap="3" count="109"/>
+      <line num="1370" type="stmt" count="109"/>
+      <line num="1371" type="stmt" count="109"/>
+      <line num="1373" type="stmt" count="109"/>
+      <line num="1374" type="stmt" count="108"/>
+      <line num="1377" type="stmt" count="109"/>
+      <line num="1379" type="stmt" count="109"/>
+      <line num="1381" type="stmt" count="109"/>
+      <line num="1382" type="stmt" count="103"/>
+      <line num="1385" type="stmt" count="108"/>
+      <line num="1391" type="method" name="readString" visibility="public" complexity="2" crap="2" count="105"/>
+      <line num="1393" type="stmt" count="105"/>
+      <line num="1394" type="stmt" count="105"/>
+      <line num="1395" type="stmt" count="105"/>
+      <line num="1396" type="stmt" count="1"/>
+      <line num="1398" type="stmt" count="104"/>
+      <line num="1399" type="stmt" count="104"/>
+      <line num="1401" type="stmt" count="104"/>
+      <line num="1407" type="method" name="readFile" visibility="public" complexity="1" crap="1" count="5"/>
+      <line num="1409" type="stmt" count="5"/>
+      <line num="1411" type="stmt" count="4"/>
+      <line num="1417" type="method" name="getDOM" visibility="private" complexity="2" crap="2" count="114"/>
+      <line num="1419" type="stmt" count="114"/>
+      <line num="1420" type="stmt" count="114"/>
+      <line num="1421" type="stmt" count="114"/>
+      <line num="1422" type="stmt" count="1"/>
+      <line num="1423" type="stmt" count="1"/>
+      <line num="1425" type="stmt" count="113"/>
+      <line num="1427" type="stmt" count="113"/>
+      <line num="1430" type="method" name="againstDOMNodeList" visibility="private" complexity="3" crap="3" count="113"/>
+      <line num="1432" type="stmt" count="113"/>
+      <line num="1433" type="stmt" count="113"/>
+      <line num="1437" type="stmt" count="113"/>
+      <line num="1439" type="stmt" count="113"/>
+      <line num="1440" type="stmt" count="113"/>
+      <line num="1445" type="method" name="loadTypeWithCallback" visibility="private" complexity="4" crap="4" count="113"/>
+      <line num="1450" type="stmt" count="113"/>
+      <line num="1452" type="stmt" count="113"/>
+      <line num="1453" type="stmt" count="113"/>
+      <line num="1454" type="stmt" count="113"/>
+      <line num="1455" type="stmt" count="113"/>
+      <line num="1456" type="stmt" count="113"/>
+      <line num="1457" type="stmt" count="113"/>
+      <line num="1458" type="stmt" count="113"/>
+      <line num="1461" type="stmt" count="113"/>
+      <line num="1462" type="stmt" count="113"/>
+      <line num="1466" type="method" name="createElement" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="1468" type="stmt" count="113"/>
+      <line num="1469" type="stmt" count="113"/>
+      <line num="1470" type="stmt" count="113"/>
+      <line num="1471" type="stmt" count="113"/>
+      <line num="1473" type="stmt" count="113"/>
+      <line num="1476" type="method" name="fillElement" visibility="private" complexity="7" crap="7" count="113"/>
+      <line num="1478" type="stmt" count="113"/>
+      <line num="1479" type="stmt" count="113"/>
+      <line num="1480" type="stmt" count="113"/>
+      <line num="1481" type="stmt" count="113"/>
+      <line num="1482" type="stmt" count="113"/>
+      <line num="1484" type="stmt" count="113"/>
+      <line num="1485" type="stmt" count="113"/>
+      <line num="1487" type="stmt" count="113"/>
+      <line num="1488" type="stmt" count="113"/>
+      <line num="1491" type="stmt" count="113"/>
+      <line num="1492" type="stmt" count="4"/>
+      <line num="1495" type="stmt" count="113"/>
+      <line num="1496" type="stmt" count="113"/>
+      <line num="1497" type="stmt" count="6"/>
+      <line num="1498" type="stmt" count="113"/>
+      <line num="1499" type="stmt" count="113"/>
+      <line num="1501" type="stmt" count="113"/>
+      <line num="1502" type="stmt" count="113"/>
+      <line num="1503" type="stmt" count="113"/>
+      <line num="1504" type="stmt" count="113"/>
+      <line num="1506" type="stmt" count="113"/>
+      <line num="1510" type="stmt" count="113"/>
+      <line num="1513" type="method" name="createAnyElement" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="1515" type="stmt" count="113"/>
+      <line num="1516" type="stmt" count="113"/>
+      <line num="1518" type="stmt" count="113"/>
+      <line num="1521" type="method" name="fillAnyElement" visibility="private" complexity="4" crap="4" count="113"/>
+      <line num="1523" type="stmt" count="113"/>
+      <line num="1524" type="stmt" count="113"/>
+      <line num="1526" type="stmt" count="113"/>
+      <line num="1527" type="stmt" count="2"/>
+      <line num="1530" type="stmt" count="113"/>
+      <line num="1531" type="stmt" count="3"/>
+      <line num="1534" type="stmt" count="113"/>
+      <line num="1535" type="stmt" count="113"/>
+      <line num="1536" type="stmt" count="113"/>
+      <line num="1537" type="stmt" count="113"/>
+      <line num="1540" type="stmt" count="113"/>
+      <line num="1543" type="method" name="addAttributeFromAttributeOrRef" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="1549" type="stmt" count="113"/>
+      <line num="1550" type="stmt" count="113"/>
+      <line num="1551" type="stmt" count="113"/>
+      <line num="1552" type="stmt" count="113"/>
+      <line num="1553" type="stmt" count="113"/>
+      <line num="1555" type="stmt" count="113"/>
+      <line num="1558" type="method" name="findSomethingLikeAttributeGroup" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="1564" type="stmt" count="113"/>
+      <line num="1565" type="stmt" count="113"/>
+      <line num="1568" type="method" name="setLoadedFile" visibility="private" complexity="1" crap="1" count="113"/>
+      <line num="1570" type="stmt" count="113"/>
+      <line num="1573" type="method" name="setLoadedSchemaFromElement" visibility="private" complexity="2" crap="2" count="113"/>
+      <line num="1575" type="stmt" count="113"/>
+      <line num="1576" type="stmt" count="113"/>
+      <line num="1580" type="method" name="setLoadedSchema" visibility="private" complexity="3" crap="3" count="113"/>
+      <line num="1582" type="stmt" count="113"/>
+      <line num="1583" type="stmt" count="113"/>
+      <line num="1585" type="stmt" count="113"/>
+      <line num="1586" type="stmt" count="113"/>
+      <line num="1590" type="method" name="setSchemaThingsFromNode" visibility="private" complexity="3" crap="3.14" count="113"/>
+      <line num="1595" type="stmt" count="113"/>
+      <line num="1597" type="stmt" count="113"/>
+      <line num="1598" type="stmt" count="113"/>
+      <line num="1599" type="stmt" count="0"/>
+      <line num="1600" type="stmt" count="0"/>
+      <line num="1602" type="stmt" count="113"/>
+      <line num="1603" type="stmt" count="113"/>
+      <line num="1604" type="stmt" count="113"/>
+      <metrics loc="1607" ncloc="1502" classes="1" methods="76" coveredmethods="62" conditionals="0" coveredconditionals="0" statements="785" coveredstatements="752" elements="861" coveredelements="814"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Utils/UrlUtils.php">
       <class name="GoetasWebservices\XML\XSDReader\Utils\UrlUtils" namespace="global">
         <metrics complexity="14" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="44" coveredstatements="43" elements="48" coveredelements="46"/>
       </class>
-      <line num="9" type="method" name="resolveRelativeUrl" visibility="public" complexity="5" crap="5" count="113"/>
-      <line num="11" type="stmt" count="113"/>
+      <line num="9" type="method" name="resolveRelativeUrl" visibility="public" complexity="5" crap="5" count="122"/>
+      <line num="11" type="stmt" count="122"/>
       <line num="12" type="stmt" count="2"/>
-      <line num="15" type="stmt" count="112"/>
-      <line num="16" type="stmt" count="104"/>
+      <line num="15" type="stmt" count="121"/>
+      <line num="16" type="stmt" count="113"/>
       <line num="19" type="stmt" count="10"/>
       <line num="20" type="stmt" count="2"/>
       <line num="23" type="stmt" count="10"/>
@@ -1552,6 +1554,6 @@
       <line num="106" type="stmt" count="8"/>
       <metrics loc="109" ncloc="89" classes="1" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="44" coveredstatements="43" elements="48" coveredelements="46"/>
     </file>
-    <metrics files="54" loc="3515" ncloc="3217" classes="26" methods="217" coveredmethods="177" conditionals="0" coveredconditionals="0" statements="1052" coveredstatements="992" elements="1269" coveredelements="1169"/>
+    <metrics files="54" loc="3505" ncloc="3220" classes="26" methods="217" coveredmethods="176" conditionals="0" coveredconditionals="0" statements="1054" coveredstatements="994" elements="1271" coveredelements="1170"/>
   </project>
 </coverage>

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -212,16 +212,42 @@ class TypesTest extends BaseTest
         self::assertEquals($expected, $elements[0]->getMax());
     }
 
+    /**
+     * @dataProvider getMaxOccurencesOverride
+     */
+    public function testSequenceChoiceMaxOccursOverride($sequenceMaxOccurs, $childMaxOccurs, $expected): void
+    {
+        $schema = $this->reader->readString(
+            '
+            <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                <xs:complexType name="complexType">
+                    <xs:sequence maxOccurs="' . $sequenceMaxOccurs . '" >
+                        <xs:choice>
+                            <xs:element name="el1" maxOccurs="' . $childMaxOccurs . '" type="xs:string"></xs:element>
+                        </xs:choice>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:schema>'
+        );
+
+        $complex = $schema->findType('complexType', 'http://www.example.com');
+        self::assertInstanceOf(ComplexType::class, $complex);
+        $choice = $complex->getElements()[0];
+        $elements = $choice->getElements();
+
+        self::assertEquals($expected, $elements[0]->getMax());
+    }
+
     public function getMaxOccurencesOverride(): array
     {
         return [
             ['0', '5', 5], // maxOccurs=0 is ignored
-            ['1', '5', 5],
-            ['2', '5', 2], // 2 in this case just means "many"
-            ['4', '5', 4],
-            ['6', '5', 6],
-            ['unbounded', '5', 5],
-            ['5', 'unbounded', 5],
+            ['1', '5', -1],
+            ['2', '5', -1],
+            ['4', '5', -1],
+            ['6', '5', -1],
+            ['unbounded', '5', -1],
+            ['5', 'unbounded', -1],
         ];
     }
 


### PR DESCRIPTION
This PR changes the max occurs override logic for sequences:

```xml
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
    <xs:complexType name="complexType">
        <xs:sequence maxOccurs="5" >
            <xs:element name="el1" maxOccurs="3" type="xs:string"></xs:element>
        </xs:sequence>
    </xs:complexType>
</xs:schema>
```

This actually means the element can have a maximum occurence of 15 instead of the returned 5 for el1.

It even becomes more complex if you add additional elements to the sequence:


```xml
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
    <xs:complexType name="complexType">
        <xs:sequence maxOccurs="5" >
            <xs:element name="el1" maxOccurs="3" type="xs:string"></xs:element>
            <xs:element name="el2" maxOccurs="3" type="xs:string"></xs:element>
        </xs:sequence>
    </xs:complexType>
</xs:schema>
```

Now the availability (or not) of el2 has in impact on the maximum amount of el1's that can be set:

```
// Sequence1:
<el1>foo</el1>
<el1>foo</el1>
<el2>foo</el1>

// Sequence2:
<el1>foo</el1>
<el2>foo</el1>
```

Since it obeys the order of elements:

- For sequence 1, the maximum for el1 is now at 2.
- For sequence 2, the maximum for el1 is now at 1.
- ...

It becomes even more complex once nexted choices get introduced:
(this was not supported yet, but got introduced in this PR as well)

```xml
<xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
    <xs:complexType name="complexType">
        <xs:sequence maxOccurs="2" >
            <xs:choice maxOccurs="2">
                <xs:element name="el1" maxOccurs="3" type="xs:string"></xs:element>
                <xs:element name="el2" maxOccurs="3" type="xs:string"></xs:element>
            </xs:choice>
        </xs:sequence>
    </xs:complexType>
</xs:schema>
```

Now both the sequence count, choice count and element occurence count have an impact on the maximum amount of elements.

Since this is all becoming way too complex and unreliable, I suggest to set the maximum occurences to `-1` instead (which means you can have many elements).
For code generation, this should result in an `array` anyways.


More context:
https://github.com/phpro/soap-client/issues/540

