### PR TITLE
Finding types in default namespaces

### DIFF
--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -32,7 +32,7 @@ class Schema
             return $this->typeCache[$cid];
         }
 
-        if ($this->getTargetNamespace() === $namespace) {
+        if ($this->getTargetNamespace() === $namespace || $namespace === null) {
             /**
              * @var SchemaItem|null $item
              */

--- a/src/SchemaReader.php
+++ b/src/SchemaReader.php
@@ -1042,7 +1042,7 @@ class SchemaReader
 
         // If no namespace is found, throw an exception only if a prefix was provided.
         // If no prefix was provided and the above lookup failed, this means that there
-        // was no defalut namespace defined, making the element part of no namespace.
+        // was no default namespace defined, making the element part of no namespace.
         // In this case, we should not throw an exception since this is valid xml.
         if (!$namespace && null !== $prefix) {
             throw new TypeException(sprintf("Can't find namespace for prefix '%s', at line %d in %s ", $prefix, $node->getLineNo(), $node->ownerDocument->documentURI));


### PR DESCRIPTION
While using https://github.com/goetas-webservices/xsd2php the OTA unit tests failed with messages like

```
[...]
25) GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA\OTASerializationTest::testConversion
GoetasWebservices\XML\XSDReader\Exception\TypeException: Can't find type named {}#NightDurationType, at line 191 in /var/www/html/xsd2php/tests/JmsSerializer/OTA/otaxml/OTA_SimpleTypes.xsd  in /var/www/html/xsd2php/vendor/goetas-webservices/xsd-reader/src/SchemaReader.php:1136

26) GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA\PHPConversionTest::testMultiplicity
GoetasWebservices\XML\XSDReader\Exception\TypeException: Can't find type named {}#ary, at line 6 in schema.xsd

27) GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA\PHPConversionTest::testNestedMultiplicity
GoetasWebservices\XML\XSDReader\Exception\TypeException: Can't find type named {}#ary, at line 5 in schema.xsd

28) GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA\PHPConversionTest::testMultipleArrayTypes
GoetasWebservices\XML\XSDReader\Exception\TypeException: Can't find type named {}#ArrayOfStrings, at line 13 in schema.xsd
```

