### PR TITLE
Propagate occurrences from a repeating choice to its members

### DIFF
--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1757414503">
-  <project timestamp="1757414503">
+<coverage generated="1781182060">
+  <project timestamp="1781182060">
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Documentation/DocumentationReader.php">
       <metrics loc="11" ncloc="11" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
     </file>
@@ -8,17 +8,17 @@
       <class name="GoetasWebservices\XML\XSDReader\Documentation\StandardDocumentationReader" namespace="global">
         <metrics complexity="8" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="10" coveredstatements="10" elements="11" coveredelements="11"/>
       </class>
-      <line num="9" type="method" name="get" visibility="public" complexity="8" crap="8" count="118"/>
-      <line num="11" type="stmt" count="118"/>
-      <line num="16" type="stmt" count="118"/>
-      <line num="17" type="stmt" count="118"/>
-      <line num="21" type="stmt" count="118"/>
-      <line num="22" type="stmt" count="118"/>
-      <line num="23" type="stmt" count="117"/>
-      <line num="24" type="stmt" count="113"/>
-      <line num="26" type="stmt" count="117"/>
-      <line num="32" type="stmt" count="118"/>
-      <line num="34" type="stmt" count="118"/>
+      <line num="9" type="method" name="get" visibility="public" complexity="8" crap="8" count="121"/>
+      <line num="11" type="stmt" count="121"/>
+      <line num="16" type="stmt" count="121"/>
+      <line num="17" type="stmt" count="121"/>
+      <line num="21" type="stmt" count="121"/>
+      <line num="22" type="stmt" count="121"/>
+      <line num="23" type="stmt" count="120"/>
+      <line num="24" type="stmt" count="116"/>
+      <line num="26" type="stmt" count="120"/>
+      <line num="32" type="stmt" count="121"/>
+      <line num="34" type="stmt" count="121"/>
       <metrics loc="37" ncloc="31" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="10" coveredstatements="10" elements="11" coveredelements="11"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Exception/IOException.php">
@@ -37,15 +37,15 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\AbstractNamedGroupItem" namespace="global">
         <metrics complexity="4" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="4" elements="9" coveredelements="7"/>
       </class>
-      <line num="15" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="17" type="stmt" count="113"/>
-      <line num="18" type="stmt" count="113"/>
+      <line num="15" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="17" type="stmt" count="116"/>
+      <line num="18" type="stmt" count="116"/>
       <line num="21" type="method" name="getDoc" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="23" type="stmt" count="0"/>
-      <line num="26" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="28" type="stmt" count="113"/>
-      <line num="31" type="method" name="getSchema" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="33" type="stmt" count="113"/>
+      <line num="26" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="28" type="stmt" count="116"/>
+      <line num="31" type="method" name="getSchema" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="33" type="stmt" count="116"/>
       <metrics loc="36" ncloc="36" classes="1" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="4" elements="9" coveredelements="7"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Attribute/AbstractAttributeItem.php">
@@ -58,20 +58,20 @@
       <line num="31" type="stmt" count="0"/>
       <line num="34" type="method" name="getDefault" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="36" type="stmt" count="0"/>
-      <line num="39" type="method" name="setDefault" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="41" type="stmt" count="113"/>
+      <line num="39" type="method" name="setDefault" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="41" type="stmt" count="116"/>
       <line num="44" type="method" name="isQualified" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="46" type="stmt" count="2"/>
-      <line num="49" type="method" name="setQualified" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="51" type="stmt" count="113"/>
+      <line num="49" type="method" name="setQualified" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="51" type="stmt" count="116"/>
       <line num="54" type="method" name="isNil" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="56" type="stmt" count="1"/>
       <line num="59" type="method" name="setNil" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="61" type="stmt" count="1"/>
       <line num="64" type="method" name="getUse" visibility="public" complexity="1" crap="1" count="5"/>
       <line num="66" type="stmt" count="5"/>
-      <line num="69" type="method" name="setUse" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="71" type="stmt" count="113"/>
+      <line num="69" type="method" name="setUse" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="71" type="stmt" count="116"/>
       <metrics loc="74" ncloc="74" classes="1" methods="10" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="10" coveredstatements="7" elements="20" coveredelements="14"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Attribute/Attribute.php">
@@ -87,8 +87,8 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeContainerTrait" namespace="global">
         <metrics complexity="2" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
       </class>
-      <line num="14" type="method" name="addAttribute" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="16" type="stmt" count="113"/>
+      <line num="14" type="method" name="addAttribute" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="16" type="stmt" count="116"/>
       <line num="22" type="method" name="getAttributes" visibility="public" complexity="1" crap="1" count="12"/>
       <line num="24" type="stmt" count="12"/>
       <metrics loc="27" ncloc="21" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
@@ -106,9 +106,9 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeRef" namespace="global">
         <metrics complexity="4" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="5" elements="9" coveredelements="9"/>
       </class>
-      <line num="13" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="15" type="stmt" count="113"/>
-      <line num="16" type="stmt" count="113"/>
+      <line num="13" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="15" type="stmt" count="116"/>
+      <line num="16" type="stmt" count="116"/>
       <line num="19" type="method" name="getName" visibility="public" complexity="1" crap="1" count="3"/>
       <line num="21" type="stmt" count="3"/>
       <line num="24" type="method" name="getReferencedAttribute" visibility="public" complexity="1" crap="1" count="2"/>
@@ -151,8 +151,8 @@
       </class>
       <line num="17" type="method" name="getCustomAttributes" visibility="public" complexity="1" crap="1" count="5"/>
       <line num="19" type="stmt" count="5"/>
-      <line num="25" type="method" name="setCustomAttributes" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="27" type="stmt" count="113"/>
+      <line num="25" type="method" name="setCustomAttributes" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="27" type="stmt" count="116"/>
       <metrics loc="30" ncloc="21" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Element/AbstractElementSingle.php">
@@ -161,24 +161,24 @@
       </class>
       <line num="30" type="method" name="isQualified" visibility="public" complexity="1" crap="1" count="3"/>
       <line num="32" type="stmt" count="3"/>
-      <line num="35" type="method" name="setQualified" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="37" type="stmt" count="113"/>
-      <line num="40" type="method" name="isLocal" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="42" type="stmt" count="113"/>
-      <line num="45" type="method" name="setLocal" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="47" type="stmt" count="113"/>
+      <line num="35" type="method" name="setQualified" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="37" type="stmt" count="116"/>
+      <line num="40" type="method" name="isLocal" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="42" type="stmt" count="116"/>
+      <line num="45" type="method" name="setLocal" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="47" type="stmt" count="116"/>
       <line num="50" type="method" name="isNil" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="52" type="stmt" count="1"/>
       <line num="55" type="method" name="setNil" visibility="public" complexity="1" crap="1" count="4"/>
       <line num="57" type="stmt" count="4"/>
-      <line num="60" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="62" type="stmt" count="113"/>
-      <line num="65" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="67" type="stmt" count="113"/>
-      <line num="70" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="72" type="stmt" count="113"/>
-      <line num="75" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="77" type="stmt" count="113"/>
+      <line num="60" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="62" type="stmt" count="116"/>
+      <line num="65" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="67" type="stmt" count="116"/>
+      <line num="70" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="72" type="stmt" count="116"/>
+      <line num="75" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="77" type="stmt" count="116"/>
       <line num="80" type="method" name="getFixed" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="82" type="stmt" count="0"/>
       <line num="85" type="method" name="setFixed" visibility="public" complexity="1" crap="2" count="0"/>
@@ -197,8 +197,8 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\Any\Any" namespace="global">
         <metrics complexity="8" methods="8" coveredmethods="8" conditionals="0" coveredconditionals="0" statements="8" coveredstatements="8" elements="16" coveredelements="16"/>
       </class>
-      <line num="26" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="28" type="stmt" count="113"/>
+      <line num="26" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="28" type="stmt" count="116"/>
       <line num="31" type="method" name="getName" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="33" type="stmt" count="2"/>
       <line num="36" type="method" name="getNamespace" visibility="public" complexity="1" crap="1" count="2"/>
@@ -207,8 +207,8 @@
       <line num="43" type="stmt" count="3"/>
       <line num="46" type="method" name="getProcessContents" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="48" type="stmt" count="2"/>
-      <line num="51" type="method" name="setProcessContents" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="53" type="stmt" count="113"/>
+      <line num="51" type="method" name="setProcessContents" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="53" type="stmt" count="116"/>
       <line num="56" type="method" name="getId" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="58" type="stmt" count="2"/>
       <line num="61" type="method" name="setId" visibility="public" complexity="1" crap="1" count="2"/>
@@ -225,9 +225,23 @@
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Element/Choice.php">
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\Choice" namespace="global">
-        <metrics complexity="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+        <metrics complexity="6" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="13" coveredstatements="12" elements="14" coveredelements="12"/>
       </class>
-      <metrics loc="14" ncloc="14" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+      <line num="28" type="method" name="getElements" visibility="public" complexity="6" crap="6.02" count="16"/>
+      <line num="30" type="stmt" count="16"/>
+      <line num="31" type="stmt" count="16"/>
+      <line num="32" type="stmt" count="12"/>
+      <line num="35" type="stmt" count="4"/>
+      <line num="37" type="stmt" count="4"/>
+      <line num="38" type="stmt" count="4"/>
+      <line num="39" type="stmt" count="4"/>
+      <line num="40" type="stmt" count="0"/>
+      <line num="43" type="stmt" count="4"/>
+      <line num="44" type="stmt" count="4"/>
+      <line num="45" type="stmt" count="4"/>
+      <line num="46" type="stmt" count="4"/>
+      <line num="49" type="stmt" count="4"/>
+      <metrics loc="52" ncloc="38" classes="1" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="13" coveredstatements="12" elements="14" coveredelements="12"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Element/Element.php">
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\Element" namespace="global">
@@ -242,10 +256,10 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\ElementContainerTrait" namespace="global">
         <metrics complexity="2" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
       </class>
-      <line num="17" type="method" name="getElements" visibility="public" complexity="1" crap="1" count="66"/>
-      <line num="19" type="stmt" count="66"/>
-      <line num="22" type="method" name="addElement" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="24" type="stmt" count="113"/>
+      <line num="17" type="method" name="getElements" visibility="public" complexity="1" crap="1" count="69"/>
+      <line num="19" type="stmt" count="69"/>
+      <line num="22" type="method" name="addElement" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="24" type="stmt" count="116"/>
       <metrics loc="27" ncloc="21" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Element/ElementDef.php">
@@ -269,13 +283,13 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\ElementRef" namespace="global">
         <metrics complexity="4" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="5" elements="9" coveredelements="9"/>
       </class>
-      <line num="13" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="15" type="stmt" count="113"/>
-      <line num="16" type="stmt" count="113"/>
+      <line num="13" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="15" type="stmt" count="116"/>
+      <line num="16" type="stmt" count="116"/>
       <line num="19" type="method" name="getName" visibility="public" complexity="1" crap="1" count="7"/>
       <line num="21" type="stmt" count="7"/>
-      <line num="24" type="method" name="getReferencedElement" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="26" type="stmt" count="113"/>
+      <line num="24" type="method" name="getReferencedElement" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="26" type="stmt" count="116"/>
       <line num="29" type="method" name="getType" visibility="public" complexity="1" crap="1" count="6"/>
       <line num="31" type="stmt" count="6"/>
       <metrics loc="34" ncloc="34" classes="1" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="5" elements="9" coveredelements="9"/>
@@ -293,33 +307,33 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\GroupRef" namespace="global">
         <metrics complexity="13" methods="8" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="21" coveredstatements="20" elements="29" coveredelements="27"/>
       </class>
-      <line num="15" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="17" type="stmt" count="113"/>
-      <line num="18" type="stmt" count="113"/>
-      <line num="21" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="23" type="stmt" count="113"/>
-      <line num="26" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="28" type="stmt" count="113"/>
-      <line num="31" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="33" type="stmt" count="113"/>
-      <line num="36" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="38" type="stmt" count="113"/>
+      <line num="15" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="17" type="stmt" count="116"/>
+      <line num="18" type="stmt" count="116"/>
+      <line num="21" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="23" type="stmt" count="116"/>
+      <line num="26" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="28" type="stmt" count="116"/>
+      <line num="31" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="33" type="stmt" count="116"/>
+      <line num="36" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="38" type="stmt" count="116"/>
       <line num="41" type="method" name="getName" visibility="public" complexity="1" crap="1" count="9"/>
       <line num="43" type="stmt" count="9"/>
-      <line num="49" type="method" name="getElements" visibility="public" complexity="6" crap="6" count="8"/>
-      <line num="51" type="stmt" count="8"/>
-      <line num="56" type="stmt" count="8"/>
-      <line num="60" type="stmt" count="8"/>
-      <line num="62" type="stmt" count="8"/>
-      <line num="63" type="stmt" count="8"/>
-      <line num="64" type="stmt" count="4"/>
-      <line num="65" type="stmt" count="4"/>
-      <line num="68" type="stmt" count="8"/>
-      <line num="69" type="stmt" count="8"/>
-      <line num="70" type="stmt" count="2"/>
-      <line num="71" type="stmt" count="2"/>
-      <line num="74" type="stmt" count="8"/>
-      <line num="77" type="stmt" count="8"/>
+      <line num="49" type="method" name="getElements" visibility="public" complexity="6" crap="6" count="9"/>
+      <line num="51" type="stmt" count="9"/>
+      <line num="56" type="stmt" count="9"/>
+      <line num="60" type="stmt" count="9"/>
+      <line num="62" type="stmt" count="9"/>
+      <line num="63" type="stmt" count="9"/>
+      <line num="64" type="stmt" count="5"/>
+      <line num="65" type="stmt" count="5"/>
+      <line num="68" type="stmt" count="9"/>
+      <line num="69" type="stmt" count="9"/>
+      <line num="70" type="stmt" count="3"/>
+      <line num="71" type="stmt" count="3"/>
+      <line num="74" type="stmt" count="9"/>
+      <line num="77" type="stmt" count="9"/>
       <line num="80" type="method" name="addElement" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="82" type="stmt" count="0"/>
       <metrics loc="85" ncloc="76" classes="1" methods="8" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="21" coveredstatements="20" elements="29" coveredelements="27"/>
@@ -340,14 +354,14 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Element\MinMaxTrait" namespace="global">
         <metrics complexity="4" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="4" elements="8" coveredelements="8"/>
       </class>
-      <line num="13" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="15" type="stmt" count="113"/>
-      <line num="18" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="20" type="stmt" count="113"/>
-      <line num="23" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="25" type="stmt" count="113"/>
-      <line num="28" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="30" type="stmt" count="113"/>
+      <line num="13" type="method" name="getMin" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="15" type="stmt" count="116"/>
+      <line num="18" type="method" name="setMin" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="20" type="stmt" count="116"/>
+      <line num="23" type="method" name="getMax" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="25" type="stmt" count="116"/>
+      <line num="28" type="method" name="setMax" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="30" type="stmt" count="116"/>
       <metrics loc="33" ncloc="33" classes="1" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="4" elements="8" coveredelements="8"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Element/Sequence.php">
@@ -374,9 +388,9 @@
       </class>
       <line num="13" type="method" name="getBase" visibility="public" complexity="1" crap="1" count="11"/>
       <line num="15" type="stmt" count="11"/>
-      <line num="18" type="method" name="setBase" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="20" type="stmt" count="113"/>
-      <line num="22" type="stmt" count="113"/>
+      <line num="18" type="method" name="setBase" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="20" type="stmt" count="116"/>
+      <line num="22" type="stmt" count="116"/>
       <metrics loc="25" ncloc="25" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="3" elements="5" coveredelements="5"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Inheritance/Extension.php">
@@ -389,8 +403,8 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Inheritance\Restriction" namespace="global">
         <metrics complexity="3" methods="3" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="6" coveredelements="4"/>
       </class>
-      <line num="17" type="method" name="addCheck" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="19" type="stmt" count="113"/>
+      <line num="17" type="method" name="addCheck" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="19" type="stmt" count="116"/>
       <line num="25" type="method" name="getChecks" visibility="public" complexity="1" crap="1" count="10"/>
       <line num="27" type="stmt" count="10"/>
       <line num="33" type="method" name="getChecksByType" visibility="public" complexity="1" crap="2" count="0"/>
@@ -404,158 +418,158 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Item" namespace="global">
         <metrics complexity="3" methods="3" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="4" elements="7" coveredelements="7"/>
       </class>
-      <line num="16" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="18" type="stmt" count="113"/>
-      <line num="19" type="stmt" count="113"/>
-      <line num="22" type="method" name="getType" visibility="public" complexity="1" crap="1" count="39"/>
-      <line num="24" type="stmt" count="39"/>
-      <line num="27" type="method" name="setType" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="29" type="stmt" count="113"/>
+      <line num="16" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="18" type="stmt" count="116"/>
+      <line num="19" type="stmt" count="116"/>
+      <line num="22" type="method" name="getType" visibility="public" complexity="1" crap="1" count="41"/>
+      <line num="24" type="stmt" count="41"/>
+      <line num="27" type="method" name="setType" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="29" type="stmt" count="116"/>
       <metrics loc="32" ncloc="32" classes="1" methods="3" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="4" elements="7" coveredelements="7"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/NamedItemTrait.php">
       <class name="GoetasWebservices\XML\XSDReader\Schema\NamedItemTrait" namespace="global">
         <metrics complexity="2" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
       </class>
-      <line num="11" type="method" name="getName" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="13" type="stmt" count="113"/>
-      <line num="16" type="method" name="setName" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="18" type="stmt" count="113"/>
+      <line num="11" type="method" name="getName" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="13" type="stmt" count="116"/>
+      <line num="16" type="method" name="setName" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="18" type="stmt" count="116"/>
       <metrics loc="21" ncloc="21" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="4" coveredelements="4"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Schema.php">
       <class name="GoetasWebservices\XML\XSDReader\Schema\Schema" namespace="global">
         <metrics complexity="54" methods="34" coveredmethods="23" conditionals="0" coveredconditionals="0" statements="95" coveredstatements="84" elements="129" coveredelements="107"/>
       </class>
-      <line num="22" type="method" name="findSomethingNoThrow" visibility="protected" complexity="4" crap="4" count="113"/>
-      <line num="28" type="stmt" count="113"/>
-      <line num="29" type="stmt" count="113"/>
-      <line num="31" type="stmt" count="113"/>
-      <line num="32" type="stmt" count="113"/>
-      <line num="35" type="stmt" count="113"/>
-      <line num="39" type="stmt" count="113"/>
-      <line num="40" type="stmt" count="113"/>
-      <line num="41" type="stmt" count="113"/>
-      <line num="45" type="stmt" count="113"/>
-      <line num="46" type="stmt" count="113"/>
-      <line num="47" type="stmt" count="113"/>
-      <line num="48" type="stmt" count="113"/>
-      <line num="49" type="stmt" count="113"/>
-      <line num="50" type="stmt" count="113"/>
-      <line num="51" type="stmt" count="113"/>
-      <line num="52" type="stmt" count="113"/>
-      <line num="59" type="method" name="findSomethingNoThrowSchemas" visibility="protected" complexity="4" crap="4" count="113"/>
-      <line num="67" type="stmt" count="113"/>
-      <line num="68" type="stmt" count="113"/>
-      <line num="72" type="stmt" count="113"/>
-      <line num="74" type="stmt" count="113"/>
-      <line num="75" type="stmt" count="113"/>
+      <line num="22" type="method" name="findSomethingNoThrow" visibility="protected" complexity="4" crap="4" count="116"/>
+      <line num="28" type="stmt" count="116"/>
+      <line num="29" type="stmt" count="116"/>
+      <line num="31" type="stmt" count="116"/>
+      <line num="32" type="stmt" count="116"/>
+      <line num="35" type="stmt" count="116"/>
+      <line num="39" type="stmt" count="116"/>
+      <line num="40" type="stmt" count="116"/>
+      <line num="41" type="stmt" count="116"/>
+      <line num="45" type="stmt" count="116"/>
+      <line num="46" type="stmt" count="116"/>
+      <line num="47" type="stmt" count="116"/>
+      <line num="48" type="stmt" count="116"/>
+      <line num="49" type="stmt" count="116"/>
+      <line num="50" type="stmt" count="116"/>
+      <line num="51" type="stmt" count="116"/>
+      <line num="52" type="stmt" count="116"/>
+      <line num="59" type="method" name="findSomethingNoThrowSchemas" visibility="protected" complexity="4" crap="4" count="116"/>
+      <line num="67" type="stmt" count="116"/>
+      <line num="68" type="stmt" count="116"/>
+      <line num="72" type="stmt" count="116"/>
+      <line num="74" type="stmt" count="116"/>
+      <line num="75" type="stmt" count="116"/>
       <line num="80" type="stmt" count="15"/>
-      <line num="88" type="method" name="findSomething" visibility="protected" complexity="2" crap="2" count="113"/>
-      <line num="90" type="stmt" count="113"/>
-      <line num="91" type="stmt" count="113"/>
-      <line num="92" type="stmt" count="113"/>
-      <line num="93" type="stmt" count="113"/>
-      <line num="94" type="stmt" count="113"/>
-      <line num="95" type="stmt" count="113"/>
-      <line num="97" type="stmt" count="113"/>
-      <line num="98" type="stmt" count="113"/>
+      <line num="88" type="method" name="findSomething" visibility="protected" complexity="2" crap="2" count="116"/>
+      <line num="90" type="stmt" count="116"/>
+      <line num="91" type="stmt" count="116"/>
+      <line num="92" type="stmt" count="116"/>
+      <line num="93" type="stmt" count="116"/>
+      <line num="94" type="stmt" count="116"/>
+      <line num="95" type="stmt" count="116"/>
+      <line num="97" type="stmt" count="116"/>
+      <line num="98" type="stmt" count="116"/>
       <line num="101" type="stmt" count="7"/>
-      <line num="147" type="method" name="getElementsQualification" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="149" type="stmt" count="113"/>
-      <line num="152" type="method" name="setElementsQualification" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="154" type="stmt" count="113"/>
-      <line num="157" type="method" name="getAttributesQualification" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="159" type="stmt" count="113"/>
-      <line num="162" type="method" name="setAttributesQualification" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="164" type="stmt" count="113"/>
-      <line num="167" type="method" name="getTargetNamespace" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="169" type="stmt" count="113"/>
-      <line num="172" type="method" name="setTargetNamespace" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="174" type="stmt" count="113"/>
+      <line num="147" type="method" name="getElementsQualification" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="149" type="stmt" count="116"/>
+      <line num="152" type="method" name="setElementsQualification" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="154" type="stmt" count="116"/>
+      <line num="157" type="method" name="getAttributesQualification" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="159" type="stmt" count="116"/>
+      <line num="162" type="method" name="setAttributesQualification" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="164" type="stmt" count="116"/>
+      <line num="167" type="method" name="getTargetNamespace" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="169" type="stmt" count="116"/>
+      <line num="172" type="method" name="setTargetNamespace" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="174" type="stmt" count="116"/>
       <line num="180" type="method" name="getTypes" visibility="public" complexity="1" crap="1" count="7"/>
       <line num="182" type="stmt" count="7"/>
-      <line num="188" type="method" name="getElements" visibility="public" complexity="1" crap="1" count="17"/>
-      <line num="190" type="stmt" count="17"/>
-      <line num="196" type="method" name="getSchemas" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="198" type="stmt" count="113"/>
+      <line num="188" type="method" name="getElements" visibility="public" complexity="1" crap="1" count="19"/>
+      <line num="190" type="stmt" count="19"/>
+      <line num="196" type="method" name="getSchemas" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="198" type="stmt" count="116"/>
       <line num="204" type="method" name="getAttributes" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="206" type="stmt" count="1"/>
       <line num="212" type="method" name="getGroups" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="214" type="stmt" count="2"/>
       <line num="217" type="method" name="getDoc" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="219" type="stmt" count="0"/>
-      <line num="222" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="224" type="stmt" count="113"/>
-      <line num="227" type="method" name="addType" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="229" type="stmt" count="113"/>
-      <line num="232" type="method" name="addElement" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="234" type="stmt" count="113"/>
-      <line num="237" type="method" name="addSchema" visibility="public" complexity="4" crap="4.02" count="113"/>
-      <line num="239" type="stmt" count="113"/>
-      <line num="240" type="stmt" count="113"/>
-      <line num="242" type="stmt" count="113"/>
-      <line num="245" type="stmt" count="113"/>
+      <line num="222" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="224" type="stmt" count="116"/>
+      <line num="227" type="method" name="addType" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="229" type="stmt" count="116"/>
+      <line num="232" type="method" name="addElement" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="234" type="stmt" count="116"/>
+      <line num="237" type="method" name="addSchema" visibility="public" complexity="4" crap="4.02" count="116"/>
+      <line num="239" type="stmt" count="116"/>
+      <line num="240" type="stmt" count="116"/>
+      <line num="242" type="stmt" count="116"/>
+      <line num="245" type="stmt" count="116"/>
       <line num="246" type="stmt" count="0"/>
-      <line num="249" type="stmt" count="113"/>
+      <line num="249" type="stmt" count="116"/>
       <line num="250" type="stmt" count="1"/>
       <line num="252" type="stmt" count="1"/>
-      <line num="255" type="stmt" count="113"/>
-      <line num="258" type="method" name="addAttribute" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="260" type="stmt" count="113"/>
-      <line num="263" type="method" name="addGroup" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="265" type="stmt" count="113"/>
-      <line num="268" type="method" name="addAttributeGroup" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="270" type="stmt" count="113"/>
+      <line num="255" type="stmt" count="116"/>
+      <line num="258" type="method" name="addAttribute" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="260" type="stmt" count="116"/>
+      <line num="263" type="method" name="addGroup" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="265" type="stmt" count="116"/>
+      <line num="268" type="method" name="addAttributeGroup" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="270" type="stmt" count="116"/>
       <line num="276" type="method" name="getAttributeGroups" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="278" type="stmt" count="1"/>
-      <line num="281" type="method" name="getGroup" visibility="public" complexity="2" crap="2.15" count="113"/>
-      <line num="283" type="stmt" count="113"/>
-      <line num="284" type="stmt" count="113"/>
+      <line num="281" type="method" name="getGroup" visibility="public" complexity="2" crap="2.15" count="116"/>
+      <line num="283" type="stmt" count="116"/>
+      <line num="284" type="stmt" count="116"/>
       <line num="287" type="stmt" count="0"/>
-      <line num="290" type="method" name="getElement" visibility="public" complexity="2" crap="2" count="113"/>
-      <line num="292" type="stmt" count="113"/>
-      <line num="293" type="stmt" count="113"/>
+      <line num="290" type="method" name="getElement" visibility="public" complexity="2" crap="2" count="116"/>
+      <line num="292" type="stmt" count="116"/>
+      <line num="293" type="stmt" count="116"/>
       <line num="296" type="stmt" count="1"/>
-      <line num="299" type="method" name="getType" visibility="public" complexity="2" crap="2" count="113"/>
-      <line num="301" type="stmt" count="113"/>
-      <line num="302" type="stmt" count="113"/>
+      <line num="299" type="method" name="getType" visibility="public" complexity="2" crap="2" count="116"/>
+      <line num="301" type="stmt" count="116"/>
+      <line num="302" type="stmt" count="116"/>
       <line num="305" type="stmt" count="1"/>
-      <line num="308" type="method" name="getAttribute" visibility="public" complexity="2" crap="2.15" count="113"/>
-      <line num="310" type="stmt" count="113"/>
-      <line num="311" type="stmt" count="113"/>
+      <line num="308" type="method" name="getAttribute" visibility="public" complexity="2" crap="2.15" count="116"/>
+      <line num="310" type="stmt" count="116"/>
+      <line num="311" type="stmt" count="116"/>
       <line num="314" type="stmt" count="0"/>
-      <line num="317" type="method" name="getAttributeGroup" visibility="public" complexity="2" crap="2.15" count="113"/>
-      <line num="319" type="stmt" count="113"/>
-      <line num="320" type="stmt" count="113"/>
+      <line num="317" type="method" name="getAttributeGroup" visibility="public" complexity="2" crap="2.15" count="116"/>
+      <line num="319" type="stmt" count="116"/>
+      <line num="320" type="stmt" count="116"/>
       <line num="323" type="stmt" count="0"/>
       <line num="326" type="method" name="__toString" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="328" type="stmt" count="0"/>
-      <line num="331" type="method" name="findType" visibility="public" complexity="2" crap="2.06" count="113"/>
-      <line num="333" type="stmt" count="113"/>
-      <line num="335" type="stmt" count="113"/>
+      <line num="331" type="method" name="findType" visibility="public" complexity="2" crap="2.06" count="116"/>
+      <line num="333" type="stmt" count="116"/>
+      <line num="335" type="stmt" count="116"/>
       <line num="336" type="stmt" count="0"/>
-      <line num="339" type="stmt" count="113"/>
-      <line num="342" type="method" name="findGroup" visibility="public" complexity="2" crap="2.06" count="113"/>
-      <line num="344" type="stmt" count="113"/>
-      <line num="346" type="stmt" count="113"/>
+      <line num="339" type="stmt" count="116"/>
+      <line num="342" type="method" name="findGroup" visibility="public" complexity="2" crap="2.06" count="116"/>
+      <line num="344" type="stmt" count="116"/>
+      <line num="346" type="stmt" count="116"/>
       <line num="347" type="stmt" count="0"/>
-      <line num="350" type="stmt" count="113"/>
-      <line num="353" type="method" name="findElement" visibility="public" complexity="2" crap="2.06" count="113"/>
-      <line num="355" type="stmt" count="113"/>
-      <line num="357" type="stmt" count="113"/>
+      <line num="350" type="stmt" count="116"/>
+      <line num="353" type="method" name="findElement" visibility="public" complexity="2" crap="2.06" count="116"/>
+      <line num="355" type="stmt" count="116"/>
+      <line num="357" type="stmt" count="116"/>
       <line num="358" type="stmt" count="0"/>
-      <line num="361" type="stmt" count="113"/>
-      <line num="364" type="method" name="findAttribute" visibility="public" complexity="2" crap="2.06" count="113"/>
-      <line num="366" type="stmt" count="113"/>
-      <line num="368" type="stmt" count="113"/>
+      <line num="361" type="stmt" count="116"/>
+      <line num="364" type="method" name="findAttribute" visibility="public" complexity="2" crap="2.06" count="116"/>
+      <line num="366" type="stmt" count="116"/>
+      <line num="368" type="stmt" count="116"/>
       <line num="369" type="stmt" count="0"/>
-      <line num="372" type="stmt" count="113"/>
-      <line num="375" type="method" name="findAttributeGroup" visibility="public" complexity="2" crap="2.06" count="113"/>
-      <line num="377" type="stmt" count="113"/>
-      <line num="379" type="stmt" count="113"/>
+      <line num="372" type="stmt" count="116"/>
+      <line num="375" type="method" name="findAttributeGroup" visibility="public" complexity="2" crap="2.06" count="116"/>
+      <line num="377" type="stmt" count="116"/>
+      <line num="379" type="stmt" count="116"/>
       <line num="380" type="stmt" count="0"/>
-      <line num="383" type="stmt" count="113"/>
+      <line num="383" type="stmt" count="116"/>
       <metrics loc="386" ncloc="329" classes="1" methods="34" coveredmethods="23" conditionals="0" coveredconditionals="0" statements="95" coveredstatements="84" elements="129" coveredelements="107"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/SchemaItem.php">
@@ -565,12 +579,12 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\SchemaItemTrait" namespace="global">
         <metrics complexity="3" methods="3" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="3" elements="6" coveredelements="6"/>
       </class>
-      <line num="13" type="method" name="getSchema" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="15" type="stmt" count="113"/>
+      <line num="13" type="method" name="getSchema" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="15" type="stmt" count="116"/>
       <line num="18" type="method" name="getDoc" visibility="public" complexity="1" crap="1" count="4"/>
       <line num="20" type="stmt" count="4"/>
-      <line num="23" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="25" type="stmt" count="113"/>
+      <line num="23" type="method" name="setDoc" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="25" type="stmt" count="116"/>
       <metrics loc="28" ncloc="28" classes="1" methods="3" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="3" elements="6" coveredelements="6"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Type/BaseComplexType.php">
@@ -585,9 +599,9 @@
       </class>
       <line num="16" type="method" name="isMixed" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="18" type="stmt" count="1"/>
-      <line num="21" type="method" name="setMixed" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="23" type="stmt" count="113"/>
-      <line num="25" type="stmt" count="113"/>
+      <line num="21" type="method" name="setMixed" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="23" type="stmt" count="116"/>
+      <line num="25" type="stmt" count="116"/>
       <metrics loc="28" ncloc="28" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="3" elements="5" coveredelements="5"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Type/ComplexTypeSimpleContent.php">
@@ -600,41 +614,41 @@
       <class name="GoetasWebservices\XML\XSDReader\Schema\Type\SimpleType" namespace="global">
         <metrics complexity="4" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="3" elements="8" coveredelements="6"/>
       </class>
-      <line num="16" type="method" name="addUnion" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="18" type="stmt" count="113"/>
+      <line num="16" type="method" name="addUnion" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="18" type="stmt" count="116"/>
       <line num="24" type="method" name="getUnions" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="26" type="stmt" count="2"/>
       <line num="29" type="method" name="getList" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="31" type="stmt" count="0"/>
-      <line num="34" type="method" name="setList" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="36" type="stmt" count="113"/>
+      <line num="34" type="method" name="setList" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="36" type="stmt" count="116"/>
       <metrics loc="39" ncloc="33" classes="1" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="4" coveredstatements="3" elements="8" coveredelements="6"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Schema/Type/Type.php">
       <class name="GoetasWebservices\XML\XSDReader\Schema\Type\Type" namespace="global">
         <metrics complexity="12" methods="10" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="11" coveredstatements="8" elements="21" coveredelements="15"/>
       </class>
-      <line num="27" type="method" name="__construct" visibility="public" complexity="2" crap="2" count="113"/>
-      <line num="29" type="stmt" count="113"/>
-      <line num="30" type="stmt" count="113"/>
-      <line num="33" type="method" name="getName" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="35" type="stmt" count="113"/>
+      <line num="27" type="method" name="__construct" visibility="public" complexity="2" crap="2" count="116"/>
+      <line num="29" type="stmt" count="116"/>
+      <line num="30" type="stmt" count="116"/>
+      <line num="33" type="method" name="getName" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="35" type="stmt" count="116"/>
       <line num="38" type="method" name="__toString" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="40" type="stmt" count="0"/>
       <line num="43" type="method" name="isAbstract" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="45" type="stmt" count="0"/>
-      <line num="48" type="method" name="setAbstract" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="50" type="stmt" count="113"/>
+      <line num="48" type="method" name="setAbstract" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="50" type="stmt" count="116"/>
       <line num="56" type="method" name="getParent" visibility="public" complexity="2" crap="6" count="0"/>
       <line num="58" type="stmt" count="0"/>
       <line num="61" type="method" name="getRestriction" visibility="public" complexity="1" crap="1" count="19"/>
       <line num="63" type="stmt" count="19"/>
-      <line num="66" type="method" name="setRestriction" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="68" type="stmt" count="113"/>
+      <line num="66" type="method" name="setRestriction" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="68" type="stmt" count="116"/>
       <line num="71" type="method" name="getExtension" visibility="public" complexity="1" crap="1" count="4"/>
       <line num="73" type="stmt" count="4"/>
-      <line num="76" type="method" name="setExtension" visibility="public" complexity="1" crap="1" count="113"/>
-      <line num="78" type="stmt" count="113"/>
+      <line num="76" type="method" name="setExtension" visibility="public" complexity="1" crap="1" count="116"/>
+      <line num="78" type="stmt" count="116"/>
       <metrics loc="81" ncloc="78" classes="1" methods="10" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="11" coveredstatements="8" elements="21" coveredelements="15"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/SchemaReader.php">
@@ -648,32 +662,32 @@
       <line num="115" type="stmt" count="2"/>
       <line num="116" type="stmt" count="2"/>
       <line num="118" type="stmt" count="2"/>
-      <line num="121" type="method" name="__construct" visibility="public" complexity="2" crap="2" count="124"/>
-      <line num="123" type="stmt" count="124"/>
-      <line num="124" type="stmt" count="124"/>
-      <line num="126" type="stmt" count="124"/>
+      <line num="121" type="method" name="__construct" visibility="public" complexity="2" crap="2" count="127"/>
+      <line num="123" type="stmt" count="127"/>
+      <line num="124" type="stmt" count="127"/>
+      <line num="126" type="stmt" count="127"/>
       <line num="135" type="method" name="addKnownSchemaLocation" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="137" type="stmt" count="1"/>
       <line num="147" type="method" name="addKnownNamespaceSchemaLocation" visibility="public" complexity="1" crap="1" count="1"/>
       <line num="149" type="stmt" count="1"/>
-      <line num="152" type="method" name="loadAttributeGroup" visibility="private" complexity="3" crap="3" count="113"/>
-      <line num="156" type="stmt" count="113"/>
-      <line num="157" type="stmt" count="113"/>
-      <line num="158" type="stmt" count="113"/>
-      <line num="160" type="stmt" count="113"/>
-      <line num="161" type="stmt" count="113"/>
-      <line num="162" type="stmt" count="113"/>
-      <line num="163" type="stmt" count="113"/>
-      <line num="164" type="stmt" count="113"/>
-      <line num="165" type="stmt" count="113"/>
-      <line num="166" type="stmt" count="113"/>
-      <line num="167" type="stmt" count="113"/>
-      <line num="168" type="stmt" count="113"/>
-      <line num="169" type="stmt" count="113"/>
-      <line num="170" type="stmt" count="113"/>
-      <line num="171" type="stmt" count="113"/>
-      <line num="172" type="stmt" count="113"/>
-      <line num="173" type="stmt" count="113"/>
+      <line num="152" type="method" name="loadAttributeGroup" visibility="private" complexity="3" crap="3" count="116"/>
+      <line num="156" type="stmt" count="116"/>
+      <line num="157" type="stmt" count="116"/>
+      <line num="158" type="stmt" count="116"/>
+      <line num="160" type="stmt" count="116"/>
+      <line num="161" type="stmt" count="116"/>
+      <line num="162" type="stmt" count="116"/>
+      <line num="163" type="stmt" count="116"/>
+      <line num="164" type="stmt" count="116"/>
+      <line num="165" type="stmt" count="116"/>
+      <line num="166" type="stmt" count="116"/>
+      <line num="167" type="stmt" count="116"/>
+      <line num="168" type="stmt" count="116"/>
+      <line num="169" type="stmt" count="116"/>
+      <line num="170" type="stmt" count="116"/>
+      <line num="171" type="stmt" count="116"/>
+      <line num="172" type="stmt" count="116"/>
+      <line num="173" type="stmt" count="116"/>
       <line num="174" type="stmt" count="1"/>
       <line num="175" type="stmt" count="1"/>
       <line num="176" type="stmt" count="1"/>
@@ -681,283 +695,283 @@
       <line num="178" type="stmt" count="1"/>
       <line num="179" type="stmt" count="1"/>
       <line num="180" type="stmt" count="1"/>
-      <line num="182" type="stmt" count="113"/>
-      <line num="183" type="stmt" count="113"/>
-      <line num="184" type="stmt" count="113"/>
-      <line num="187" type="method" name="getAttributeFromAttributeOrRef" visibility="private" complexity="4" crap="4" count="113"/>
-      <line num="192" type="stmt" count="113"/>
-      <line num="193" type="stmt" count="113"/>
-      <line num="194" type="stmt" count="113"/>
-      <line num="195" type="stmt" count="113"/>
-      <line num="196" type="stmt" count="113"/>
-      <line num="197" type="stmt" count="113"/>
-      <line num="199" type="stmt" count="113"/>
-      <line num="200" type="stmt" count="113"/>
-      <line num="203" type="stmt" count="113"/>
-      <line num="209" type="stmt" count="113"/>
-      <line num="212" type="stmt" count="113"/>
-      <line num="215" type="method" name="createAttribute" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="217" type="stmt" count="113"/>
-      <line num="218" type="stmt" count="113"/>
-      <line num="219" type="stmt" count="113"/>
-      <line num="220" type="stmt" count="113"/>
-      <line num="222" type="stmt" count="113"/>
-      <line num="225" type="method" name="fillAttribute" visibility="private" complexity="6" crap="6.01" count="113"/>
-      <line num="227" type="stmt" count="113"/>
+      <line num="182" type="stmt" count="116"/>
+      <line num="183" type="stmt" count="116"/>
+      <line num="184" type="stmt" count="116"/>
+      <line num="187" type="method" name="getAttributeFromAttributeOrRef" visibility="private" complexity="4" crap="4" count="116"/>
+      <line num="192" type="stmt" count="116"/>
+      <line num="193" type="stmt" count="116"/>
+      <line num="194" type="stmt" count="116"/>
+      <line num="195" type="stmt" count="116"/>
+      <line num="196" type="stmt" count="116"/>
+      <line num="197" type="stmt" count="116"/>
+      <line num="199" type="stmt" count="116"/>
+      <line num="200" type="stmt" count="116"/>
+      <line num="203" type="stmt" count="116"/>
+      <line num="209" type="stmt" count="116"/>
+      <line num="212" type="stmt" count="116"/>
+      <line num="215" type="method" name="createAttribute" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="217" type="stmt" count="116"/>
+      <line num="218" type="stmt" count="116"/>
+      <line num="219" type="stmt" count="116"/>
+      <line num="220" type="stmt" count="116"/>
+      <line num="222" type="stmt" count="116"/>
+      <line num="225" type="method" name="fillAttribute" visibility="private" complexity="6" crap="6.01" count="116"/>
+      <line num="227" type="stmt" count="116"/>
       <line num="228" type="stmt" count="0"/>
-      <line num="230" type="stmt" count="113"/>
-      <line num="231" type="stmt" count="113"/>
-      <line num="233" type="stmt" count="113"/>
+      <line num="230" type="stmt" count="116"/>
+      <line num="231" type="stmt" count="116"/>
+      <line num="233" type="stmt" count="116"/>
       <line num="234" type="stmt" count="1"/>
-      <line num="237" type="stmt" count="113"/>
-      <line num="238" type="stmt" count="113"/>
+      <line num="237" type="stmt" count="116"/>
+      <line num="238" type="stmt" count="116"/>
       <line num="239" type="stmt" count="2"/>
-      <line num="240" type="stmt" count="113"/>
-      <line num="241" type="stmt" count="113"/>
-      <line num="243" type="stmt" count="113"/>
-      <line num="244" type="stmt" count="113"/>
-      <line num="247" type="stmt" count="113"/>
-      <line num="253" type="method" name="loadCustomAttributesForElement" visibility="private" complexity="4" crap="4" count="113"/>
-      <line num="255" type="stmt" count="113"/>
-      <line num="256" type="stmt" count="113"/>
-      <line num="257" type="stmt" count="113"/>
+      <line num="240" type="stmt" count="116"/>
+      <line num="241" type="stmt" count="116"/>
+      <line num="243" type="stmt" count="116"/>
+      <line num="244" type="stmt" count="116"/>
+      <line num="247" type="stmt" count="116"/>
+      <line num="253" type="method" name="loadCustomAttributesForElement" visibility="private" complexity="4" crap="4" count="116"/>
+      <line num="255" type="stmt" count="116"/>
+      <line num="256" type="stmt" count="116"/>
+      <line num="257" type="stmt" count="116"/>
       <line num="258" type="stmt" count="5"/>
       <line num="259" type="stmt" count="5"/>
       <line num="260" type="stmt" count="5"/>
       <line num="261" type="stmt" count="5"/>
       <line num="262" type="stmt" count="5"/>
-      <line num="266" type="stmt" count="113"/>
-      <line num="269" type="method" name="loadAttributeOrElementDef" visibility="private" complexity="2" crap="2" count="113"/>
-      <line num="275" type="stmt" count="113"/>
-      <line num="276" type="stmt" count="113"/>
-      <line num="277" type="stmt" count="113"/>
-      <line num="278" type="stmt" count="113"/>
-      <line num="279" type="stmt" count="113"/>
-      <line num="280" type="stmt" count="113"/>
-      <line num="282" type="stmt" count="113"/>
-      <line num="283" type="stmt" count="113"/>
-      <line num="284" type="stmt" count="113"/>
-      <line num="285" type="stmt" count="113"/>
-      <line num="288" type="stmt" count="113"/>
-      <line num="289" type="stmt" count="113"/>
-      <line num="290" type="stmt" count="113"/>
-      <line num="293" type="method" name="loadElementDef" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="295" type="stmt" count="113"/>
-      <line num="298" type="method" name="loadAttributeDef" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="300" type="stmt" count="113"/>
-      <line num="303" type="method" name="getDocumentation" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="305" type="stmt" count="113"/>
-      <line num="311" type="method" name="schemaNode" visibility="private" complexity="11" crap="11.02" count="113"/>
-      <line num="313" type="stmt" count="113"/>
-      <line num="314" type="stmt" count="113"/>
-      <line num="316" type="stmt" count="113"/>
-      <line num="317" type="stmt" count="113"/>
-      <line num="318" type="stmt" count="113"/>
-      <line num="319" type="stmt" count="113"/>
-      <line num="321" type="stmt" count="113"/>
-      <line num="322" type="stmt" count="113"/>
-      <line num="323" type="stmt" count="113"/>
-      <line num="324" type="stmt" count="113"/>
-      <line num="325" type="stmt" count="113"/>
-      <line num="326" type="stmt" count="113"/>
-      <line num="327" type="stmt" count="113"/>
-      <line num="328" type="stmt" count="113"/>
-      <line num="329" type="stmt" count="113"/>
-      <line num="330" type="stmt" count="113"/>
-      <line num="331" type="stmt" count="113"/>
-      <line num="332" type="stmt" count="113"/>
-      <line num="333" type="stmt" count="113"/>
-      <line num="334" type="stmt" count="113"/>
-      <line num="335" type="stmt" count="113"/>
-      <line num="336" type="stmt" count="113"/>
-      <line num="337" type="stmt" count="113"/>
-      <line num="338" type="stmt" count="113"/>
+      <line num="266" type="stmt" count="116"/>
+      <line num="269" type="method" name="loadAttributeOrElementDef" visibility="private" complexity="2" crap="2" count="116"/>
+      <line num="275" type="stmt" count="116"/>
+      <line num="276" type="stmt" count="116"/>
+      <line num="277" type="stmt" count="116"/>
+      <line num="278" type="stmt" count="116"/>
+      <line num="279" type="stmt" count="116"/>
+      <line num="280" type="stmt" count="116"/>
+      <line num="282" type="stmt" count="116"/>
+      <line num="283" type="stmt" count="116"/>
+      <line num="284" type="stmt" count="116"/>
+      <line num="285" type="stmt" count="116"/>
+      <line num="288" type="stmt" count="116"/>
+      <line num="289" type="stmt" count="116"/>
+      <line num="290" type="stmt" count="116"/>
+      <line num="293" type="method" name="loadElementDef" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="295" type="stmt" count="116"/>
+      <line num="298" type="method" name="loadAttributeDef" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="300" type="stmt" count="116"/>
+      <line num="303" type="method" name="getDocumentation" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="305" type="stmt" count="116"/>
+      <line num="311" type="method" name="schemaNode" visibility="private" complexity="11" crap="11.02" count="116"/>
+      <line num="313" type="stmt" count="116"/>
+      <line num="314" type="stmt" count="116"/>
+      <line num="316" type="stmt" count="116"/>
+      <line num="317" type="stmt" count="116"/>
+      <line num="318" type="stmt" count="116"/>
+      <line num="319" type="stmt" count="116"/>
+      <line num="321" type="stmt" count="116"/>
+      <line num="322" type="stmt" count="116"/>
+      <line num="323" type="stmt" count="116"/>
+      <line num="324" type="stmt" count="116"/>
+      <line num="325" type="stmt" count="116"/>
+      <line num="326" type="stmt" count="116"/>
+      <line num="327" type="stmt" count="116"/>
+      <line num="328" type="stmt" count="116"/>
+      <line num="329" type="stmt" count="116"/>
+      <line num="330" type="stmt" count="116"/>
+      <line num="331" type="stmt" count="116"/>
+      <line num="332" type="stmt" count="116"/>
+      <line num="333" type="stmt" count="116"/>
+      <line num="334" type="stmt" count="116"/>
+      <line num="335" type="stmt" count="116"/>
+      <line num="336" type="stmt" count="116"/>
+      <line num="337" type="stmt" count="116"/>
+      <line num="338" type="stmt" count="116"/>
       <line num="339" type="stmt" count="0"/>
       <line num="340" type="stmt" count="0"/>
-      <line num="341" type="stmt" count="113"/>
-      <line num="342" type="stmt" count="113"/>
-      <line num="343" type="stmt" count="113"/>
-      <line num="344" type="stmt" count="113"/>
-      <line num="345" type="stmt" count="113"/>
-      <line num="346" type="stmt" count="113"/>
-      <line num="349" type="stmt" count="113"/>
-      <line num="350" type="stmt" count="113"/>
-      <line num="352" type="stmt" count="113"/>
-      <line num="353" type="stmt" count="113"/>
-      <line num="355" type="stmt" count="113"/>
-      <line num="358" type="method" name="createGroupRef" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="360" type="stmt" count="113"/>
-      <line num="361" type="stmt" count="113"/>
-      <line num="363" type="stmt" count="113"/>
-      <line num="364" type="stmt" count="113"/>
-      <line num="366" type="stmt" count="113"/>
-      <line num="369" type="method" name="maybeSetMax" visibility="private" complexity="3" crap="3" count="113"/>
-      <line num="371" type="stmt" count="113"/>
-      <line num="372" type="stmt" count="113"/>
-      <line num="376" type="method" name="maybeSetMin" visibility="private" complexity="4" crap="4" count="113"/>
-      <line num="378" type="stmt" count="113"/>
-      <line num="379" type="stmt" count="113"/>
-      <line num="380" type="stmt" count="113"/>
+      <line num="341" type="stmt" count="116"/>
+      <line num="342" type="stmt" count="116"/>
+      <line num="343" type="stmt" count="116"/>
+      <line num="344" type="stmt" count="116"/>
+      <line num="345" type="stmt" count="116"/>
+      <line num="346" type="stmt" count="116"/>
+      <line num="349" type="stmt" count="116"/>
+      <line num="350" type="stmt" count="116"/>
+      <line num="352" type="stmt" count="116"/>
+      <line num="353" type="stmt" count="116"/>
+      <line num="355" type="stmt" count="116"/>
+      <line num="358" type="method" name="createGroupRef" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="360" type="stmt" count="116"/>
+      <line num="361" type="stmt" count="116"/>
+      <line num="363" type="stmt" count="116"/>
+      <line num="364" type="stmt" count="116"/>
+      <line num="366" type="stmt" count="116"/>
+      <line num="369" type="method" name="maybeSetMax" visibility="private" complexity="3" crap="3" count="116"/>
+      <line num="371" type="stmt" count="116"/>
+      <line num="372" type="stmt" count="116"/>
+      <line num="376" type="method" name="maybeSetMin" visibility="private" complexity="4" crap="4" count="116"/>
+      <line num="378" type="stmt" count="116"/>
+      <line num="379" type="stmt" count="116"/>
+      <line num="380" type="stmt" count="116"/>
       <line num="381" type="stmt" count="8"/>
-      <line num="386" type="method" name="maybeSetFixed" visibility="private" complexity="2" crap="2.50" count="113"/>
-      <line num="388" type="stmt" count="113"/>
+      <line num="386" type="method" name="maybeSetFixed" visibility="private" complexity="2" crap="2.50" count="116"/>
+      <line num="388" type="stmt" count="116"/>
       <line num="389" type="stmt" count="0"/>
-      <line num="393" type="method" name="maybeSetDefault" visibility="private" complexity="2" crap="2" count="113"/>
-      <line num="395" type="stmt" count="113"/>
+      <line num="393" type="method" name="maybeSetDefault" visibility="private" complexity="2" crap="2" count="116"/>
+      <line num="395" type="stmt" count="116"/>
       <line num="396" type="stmt" count="1"/>
-      <line num="400" type="method" name="maybeSetAbstract" visibility="private" complexity="2" crap="2" count="113"/>
-      <line num="402" type="stmt" count="113"/>
-      <line num="403" type="stmt" count="113"/>
-      <line num="407" type="method" name="loadSequence" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="409" type="stmt" count="113"/>
-      <line num="410" type="stmt" count="113"/>
-      <line num="412" type="stmt" count="113"/>
-      <line num="413" type="stmt" count="113"/>
-      <line num="414" type="stmt" count="113"/>
-      <line num="415" type="stmt" count="113"/>
-      <line num="416" type="stmt" count="113"/>
-      <line num="417" type="stmt" count="113"/>
-      <line num="418" type="stmt" count="113"/>
-      <line num="419" type="stmt" count="113"/>
-      <line num="420" type="stmt" count="113"/>
-      <line num="421" type="stmt" count="113"/>
-      <line num="422" type="stmt" count="113"/>
-      <line num="423" type="stmt" count="113"/>
-      <line num="426" type="method" name="loadMinFromNode" visibility="private" complexity="3" crap="3" count="113"/>
-      <line num="428" type="stmt" count="113"/>
-      <line num="429" type="stmt" count="113"/>
-      <line num="432" type="stmt" count="113"/>
-      <line num="435" type="stmt" count="113"/>
-      <line num="438" type="method" name="loadMaxFromNode" visibility="private" complexity="5" crap="5.03" count="113"/>
-      <line num="440" type="stmt" count="113"/>
-      <line num="442" type="stmt" count="113"/>
-      <line num="443" type="stmt" count="113"/>
-      <line num="446" type="stmt" count="113"/>
-      <line num="447" type="stmt" count="113"/>
-      <line num="449" type="stmt" count="113"/>
+      <line num="400" type="method" name="maybeSetAbstract" visibility="private" complexity="2" crap="2" count="116"/>
+      <line num="402" type="stmt" count="116"/>
+      <line num="403" type="stmt" count="116"/>
+      <line num="407" type="method" name="loadSequence" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="409" type="stmt" count="116"/>
+      <line num="410" type="stmt" count="116"/>
+      <line num="412" type="stmt" count="116"/>
+      <line num="413" type="stmt" count="116"/>
+      <line num="414" type="stmt" count="116"/>
+      <line num="415" type="stmt" count="116"/>
+      <line num="416" type="stmt" count="116"/>
+      <line num="417" type="stmt" count="116"/>
+      <line num="418" type="stmt" count="116"/>
+      <line num="419" type="stmt" count="116"/>
+      <line num="420" type="stmt" count="116"/>
+      <line num="421" type="stmt" count="116"/>
+      <line num="422" type="stmt" count="116"/>
+      <line num="423" type="stmt" count="116"/>
+      <line num="426" type="method" name="loadMinFromNode" visibility="private" complexity="3" crap="3" count="116"/>
+      <line num="428" type="stmt" count="116"/>
+      <line num="429" type="stmt" count="116"/>
+      <line num="432" type="stmt" count="116"/>
+      <line num="435" type="stmt" count="116"/>
+      <line num="438" type="method" name="loadMaxFromNode" visibility="private" complexity="5" crap="5.03" count="116"/>
+      <line num="440" type="stmt" count="116"/>
+      <line num="442" type="stmt" count="116"/>
+      <line num="443" type="stmt" count="116"/>
+      <line num="446" type="stmt" count="116"/>
+      <line num="447" type="stmt" count="116"/>
+      <line num="449" type="stmt" count="116"/>
       <line num="450" type="stmt" count="0"/>
-      <line num="453" type="stmt" count="113"/>
-      <line num="454" type="stmt" count="113"/>
-      <line num="458" type="stmt" count="113"/>
-      <line num="461" type="method" name="loadSequenceChildNode" visibility="private" complexity="8" crap="8" count="113"/>
-      <line num="468" type="stmt" count="113"/>
-      <line num="469" type="stmt" count="113"/>
-      <line num="470" type="stmt" count="113"/>
-      <line num="471" type="stmt" count="113"/>
-      <line num="472" type="stmt" count="113"/>
-      <line num="474" type="stmt" count="113"/>
-      <line num="475" type="stmt" count="113"/>
-      <line num="477" type="stmt" count="113"/>
-      <line num="478" type="stmt" count="113"/>
-      <line num="479" type="stmt" count="113"/>
-      <line num="480" type="stmt" count="113"/>
-      <line num="481" type="stmt" count="113"/>
-      <line num="482" type="stmt" count="113"/>
-      <line num="483" type="stmt" count="113"/>
-      <line num="484" type="stmt" count="113"/>
-      <line num="485" type="stmt" count="113"/>
-      <line num="486" type="stmt" count="113"/>
-      <line num="487" type="stmt" count="113"/>
-      <line num="488" type="stmt" count="113"/>
-      <line num="489" type="stmt" count="113"/>
-      <line num="490" type="stmt" count="113"/>
-      <line num="491" type="stmt" count="113"/>
-      <line num="492" type="stmt" count="113"/>
-      <line num="493" type="stmt" count="113"/>
-      <line num="494" type="stmt" count="113"/>
-      <line num="495" type="stmt" count="113"/>
-      <line num="496" type="stmt" count="113"/>
-      <line num="497" type="stmt" count="113"/>
-      <line num="498" type="stmt" count="113"/>
-      <line num="499" type="stmt" count="113"/>
-      <line num="500" type="stmt" count="113"/>
-      <line num="501" type="stmt" count="113"/>
-      <line num="502" type="stmt" count="113"/>
-      <line num="503" type="stmt" count="113"/>
-      <line num="504" type="stmt" count="113"/>
-      <line num="505" type="stmt" count="113"/>
-      <line num="506" type="stmt" count="113"/>
-      <line num="507" type="stmt" count="113"/>
-      <line num="508" type="stmt" count="113"/>
-      <line num="509" type="stmt" count="113"/>
-      <line num="510" type="stmt" count="113"/>
-      <line num="511" type="stmt" count="113"/>
-      <line num="512" type="stmt" count="113"/>
-      <line num="516" type="method" name="loadSequenceChildNodeLoadElement" visibility="private" complexity="6" crap="6" count="113"/>
-      <line num="523" type="stmt" count="113"/>
-      <line num="524" type="stmt" count="113"/>
-      <line num="525" type="stmt" count="113"/>
-      <line num="526" type="stmt" count="113"/>
-      <line num="527" type="stmt" count="113"/>
-      <line num="528" type="stmt" count="113"/>
-      <line num="530" type="stmt" count="113"/>
-      <line num="531" type="stmt" count="113"/>
-      <line num="534" type="stmt" count="113"/>
-      <line num="537" type="stmt" count="113"/>
-      <line num="539" type="stmt" count="113"/>
-      <line num="540" type="stmt" count="113"/>
-      <line num="543" type="stmt" count="113"/>
-      <line num="544" type="stmt" count="113"/>
-      <line num="546" type="stmt" count="113"/>
-      <line num="549" type="method" name="loadSequenceChildNodeLoadAny" visibility="private" complexity="4" crap="4.05" count="113"/>
-      <line num="556" type="stmt" count="113"/>
-      <line num="557" type="stmt" count="113"/>
-      <line num="559" type="stmt" count="113"/>
-      <line num="560" type="stmt" count="113"/>
-      <line num="563" type="stmt" count="113"/>
+      <line num="453" type="stmt" count="116"/>
+      <line num="454" type="stmt" count="116"/>
+      <line num="458" type="stmt" count="116"/>
+      <line num="461" type="method" name="loadSequenceChildNode" visibility="private" complexity="8" crap="8" count="116"/>
+      <line num="468" type="stmt" count="116"/>
+      <line num="469" type="stmt" count="116"/>
+      <line num="470" type="stmt" count="116"/>
+      <line num="471" type="stmt" count="116"/>
+      <line num="472" type="stmt" count="116"/>
+      <line num="474" type="stmt" count="116"/>
+      <line num="475" type="stmt" count="116"/>
+      <line num="477" type="stmt" count="116"/>
+      <line num="478" type="stmt" count="116"/>
+      <line num="479" type="stmt" count="116"/>
+      <line num="480" type="stmt" count="116"/>
+      <line num="481" type="stmt" count="116"/>
+      <line num="482" type="stmt" count="116"/>
+      <line num="483" type="stmt" count="116"/>
+      <line num="484" type="stmt" count="116"/>
+      <line num="485" type="stmt" count="116"/>
+      <line num="486" type="stmt" count="116"/>
+      <line num="487" type="stmt" count="116"/>
+      <line num="488" type="stmt" count="116"/>
+      <line num="489" type="stmt" count="116"/>
+      <line num="490" type="stmt" count="116"/>
+      <line num="491" type="stmt" count="116"/>
+      <line num="492" type="stmt" count="116"/>
+      <line num="493" type="stmt" count="116"/>
+      <line num="494" type="stmt" count="116"/>
+      <line num="495" type="stmt" count="116"/>
+      <line num="496" type="stmt" count="116"/>
+      <line num="497" type="stmt" count="116"/>
+      <line num="498" type="stmt" count="116"/>
+      <line num="499" type="stmt" count="116"/>
+      <line num="500" type="stmt" count="116"/>
+      <line num="501" type="stmt" count="116"/>
+      <line num="502" type="stmt" count="116"/>
+      <line num="503" type="stmt" count="116"/>
+      <line num="504" type="stmt" count="116"/>
+      <line num="505" type="stmt" count="116"/>
+      <line num="506" type="stmt" count="116"/>
+      <line num="507" type="stmt" count="116"/>
+      <line num="508" type="stmt" count="116"/>
+      <line num="509" type="stmt" count="116"/>
+      <line num="510" type="stmt" count="116"/>
+      <line num="511" type="stmt" count="116"/>
+      <line num="512" type="stmt" count="116"/>
+      <line num="516" type="method" name="loadSequenceChildNodeLoadElement" visibility="private" complexity="6" crap="6" count="116"/>
+      <line num="523" type="stmt" count="116"/>
+      <line num="524" type="stmt" count="116"/>
+      <line num="525" type="stmt" count="116"/>
+      <line num="526" type="stmt" count="116"/>
+      <line num="527" type="stmt" count="116"/>
+      <line num="528" type="stmt" count="116"/>
+      <line num="530" type="stmt" count="116"/>
+      <line num="531" type="stmt" count="116"/>
+      <line num="534" type="stmt" count="116"/>
+      <line num="537" type="stmt" count="116"/>
+      <line num="539" type="stmt" count="116"/>
+      <line num="540" type="stmt" count="116"/>
+      <line num="543" type="stmt" count="116"/>
+      <line num="544" type="stmt" count="116"/>
+      <line num="546" type="stmt" count="116"/>
+      <line num="549" type="method" name="loadSequenceChildNodeLoadAny" visibility="private" complexity="4" crap="4.05" count="116"/>
+      <line num="556" type="stmt" count="116"/>
+      <line num="557" type="stmt" count="116"/>
+      <line num="559" type="stmt" count="116"/>
+      <line num="560" type="stmt" count="116"/>
+      <line num="563" type="stmt" count="116"/>
       <line num="564" type="stmt" count="0"/>
-      <line num="566" type="stmt" count="113"/>
-      <line num="569" type="method" name="resolveSubstitutionGroup" visibility="private" complexity="2" crap="2" count="113"/>
-      <line num="575" type="stmt" count="113"/>
+      <line num="566" type="stmt" count="116"/>
+      <line num="569" type="method" name="resolveSubstitutionGroup" visibility="private" complexity="2" crap="2" count="116"/>
+      <line num="575" type="stmt" count="116"/>
       <line num="576" type="stmt" count="3"/>
       <line num="577" type="stmt" count="3"/>
       <line num="578" type="stmt" count="3"/>
-      <line num="582" type="method" name="addGroupAsElement" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="588" type="stmt" count="113"/>
-      <line num="589" type="stmt" count="113"/>
-      <line num="590" type="stmt" count="113"/>
-      <line num="591" type="stmt" count="113"/>
-      <line num="592" type="stmt" count="113"/>
-      <line num="594" type="stmt" count="113"/>
-      <line num="595" type="stmt" count="113"/>
-      <line num="598" type="method" name="loadChoiceWithChildren" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="605" type="stmt" count="113"/>
-      <line num="606" type="stmt" count="113"/>
-      <line num="608" type="stmt" count="113"/>
-      <line num="609" type="stmt" count="113"/>
-      <line num="611" type="stmt" count="113"/>
-      <line num="612" type="stmt" count="113"/>
-      <line num="613" type="stmt" count="113"/>
-      <line num="614" type="stmt" count="113"/>
-      <line num="615" type="stmt" count="113"/>
-      <line num="616" type="stmt" count="113"/>
-      <line num="617" type="stmt" count="113"/>
-      <line num="618" type="stmt" count="113"/>
-      <line num="619" type="stmt" count="113"/>
-      <line num="620" type="stmt" count="113"/>
-      <line num="621" type="stmt" count="113"/>
-      <line num="622" type="stmt" count="113"/>
-      <line num="625" type="method" name="loadGroup" visibility="private" complexity="6" crap="6" count="113"/>
-      <line num="627" type="stmt" count="113"/>
-      <line num="628" type="stmt" count="113"/>
-      <line num="629" type="stmt" count="113"/>
-      <line num="631" type="stmt" count="113"/>
+      <line num="582" type="method" name="addGroupAsElement" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="588" type="stmt" count="116"/>
+      <line num="589" type="stmt" count="116"/>
+      <line num="590" type="stmt" count="116"/>
+      <line num="591" type="stmt" count="116"/>
+      <line num="592" type="stmt" count="116"/>
+      <line num="594" type="stmt" count="116"/>
+      <line num="595" type="stmt" count="116"/>
+      <line num="598" type="method" name="loadChoiceWithChildren" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="605" type="stmt" count="116"/>
+      <line num="606" type="stmt" count="116"/>
+      <line num="608" type="stmt" count="116"/>
+      <line num="609" type="stmt" count="116"/>
+      <line num="611" type="stmt" count="116"/>
+      <line num="612" type="stmt" count="116"/>
+      <line num="613" type="stmt" count="116"/>
+      <line num="614" type="stmt" count="116"/>
+      <line num="615" type="stmt" count="116"/>
+      <line num="616" type="stmt" count="116"/>
+      <line num="617" type="stmt" count="116"/>
+      <line num="618" type="stmt" count="116"/>
+      <line num="619" type="stmt" count="116"/>
+      <line num="620" type="stmt" count="116"/>
+      <line num="621" type="stmt" count="116"/>
+      <line num="622" type="stmt" count="116"/>
+      <line num="625" type="method" name="loadGroup" visibility="private" complexity="6" crap="6" count="116"/>
+      <line num="627" type="stmt" count="116"/>
+      <line num="628" type="stmt" count="116"/>
+      <line num="629" type="stmt" count="116"/>
+      <line num="631" type="stmt" count="116"/>
       <line num="632" type="stmt" count="1"/>
-      <line num="635" type="stmt" count="113"/>
-      <line num="637" type="stmt" count="113"/>
-      <line num="638" type="stmt" count="113"/>
-      <line num="639" type="stmt" count="113"/>
-      <line num="640" type="stmt" count="113"/>
-      <line num="641" type="stmt" count="113"/>
-      <line num="642" type="stmt" count="113"/>
-      <line num="643" type="stmt" count="113"/>
-      <line num="644" type="stmt" count="113"/>
-      <line num="645" type="stmt" count="113"/>
-      <line num="646" type="stmt" count="113"/>
-      <line num="647" type="stmt" count="113"/>
-      <line num="649" type="stmt" count="113"/>
-      <line num="650" type="stmt" count="113"/>
-      <line num="651" type="stmt" count="113"/>
+      <line num="635" type="stmt" count="116"/>
+      <line num="637" type="stmt" count="116"/>
+      <line num="638" type="stmt" count="116"/>
+      <line num="639" type="stmt" count="116"/>
+      <line num="640" type="stmt" count="116"/>
+      <line num="641" type="stmt" count="116"/>
+      <line num="642" type="stmt" count="116"/>
+      <line num="643" type="stmt" count="116"/>
+      <line num="644" type="stmt" count="116"/>
+      <line num="645" type="stmt" count="116"/>
+      <line num="646" type="stmt" count="116"/>
+      <line num="647" type="stmt" count="116"/>
+      <line num="649" type="stmt" count="116"/>
+      <line num="650" type="stmt" count="116"/>
+      <line num="651" type="stmt" count="116"/>
       <line num="654" type="method" name="loadChoice" visibility="private" complexity="1" crap="2" count="0"/>
       <line num="656" type="stmt" count="0"/>
       <line num="658" type="stmt" count="0"/>
@@ -974,348 +988,348 @@
       <line num="669" type="stmt" count="0"/>
       <line num="670" type="stmt" count="0"/>
       <line num="671" type="stmt" count="0"/>
-      <line num="674" type="method" name="createChoice" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="676" type="stmt" count="113"/>
-      <line num="677" type="stmt" count="113"/>
-      <line num="678" type="stmt" count="113"/>
-      <line num="679" type="stmt" count="113"/>
-      <line num="681" type="stmt" count="113"/>
-      <line num="684" type="method" name="createSequence" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="686" type="stmt" count="113"/>
-      <line num="687" type="stmt" count="113"/>
-      <line num="688" type="stmt" count="113"/>
-      <line num="689" type="stmt" count="113"/>
-      <line num="691" type="stmt" count="113"/>
-      <line num="694" type="method" name="loadComplexType" visibility="private" complexity="6" crap="6" count="113"/>
-      <line num="699" type="stmt" count="113"/>
-      <line num="701" type="stmt" count="113"/>
-      <line num="702" type="stmt" count="113"/>
-      <line num="703" type="stmt" count="113"/>
-      <line num="704" type="stmt" count="113"/>
+      <line num="674" type="method" name="createChoice" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="676" type="stmt" count="116"/>
+      <line num="677" type="stmt" count="116"/>
+      <line num="678" type="stmt" count="116"/>
+      <line num="679" type="stmt" count="116"/>
+      <line num="681" type="stmt" count="116"/>
+      <line num="684" type="method" name="createSequence" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="686" type="stmt" count="116"/>
+      <line num="687" type="stmt" count="116"/>
+      <line num="688" type="stmt" count="116"/>
+      <line num="689" type="stmt" count="116"/>
+      <line num="691" type="stmt" count="116"/>
+      <line num="694" type="method" name="loadComplexType" visibility="private" complexity="6" crap="6" count="116"/>
+      <line num="699" type="stmt" count="116"/>
+      <line num="701" type="stmt" count="116"/>
+      <line num="702" type="stmt" count="116"/>
+      <line num="703" type="stmt" count="116"/>
+      <line num="704" type="stmt" count="116"/>
       <line num="705" type="stmt" count="1"/>
-      <line num="707" type="stmt" count="113"/>
+      <line num="707" type="stmt" count="116"/>
       <line num="708" type="stmt" count="5"/>
-      <line num="710" type="stmt" count="113"/>
-      <line num="711" type="stmt" count="113"/>
-      <line num="713" type="stmt" count="113"/>
-      <line num="715" type="stmt" count="113"/>
-      <line num="716" type="stmt" count="113"/>
-      <line num="717" type="stmt" count="113"/>
-      <line num="720" type="stmt" count="113"/>
-      <line num="721" type="stmt" count="113"/>
-      <line num="723" type="stmt" count="113"/>
-      <line num="724" type="stmt" count="113"/>
-      <line num="725" type="stmt" count="113"/>
-      <line num="726" type="stmt" count="113"/>
-      <line num="727" type="stmt" count="113"/>
-      <line num="728" type="stmt" count="113"/>
-      <line num="730" type="stmt" count="113"/>
-      <line num="731" type="stmt" count="113"/>
-      <line num="733" type="stmt" count="113"/>
-      <line num="736" type="method" name="loadComplexTypeFromChildNode" visibility="private" complexity="10" crap="10" count="113"/>
-      <line num="742" type="stmt" count="113"/>
-      <line num="743" type="stmt" count="113"/>
-      <line num="744" type="stmt" count="113"/>
-      <line num="745" type="stmt" count="113"/>
-      <line num="746" type="stmt" count="113"/>
-      <line num="748" type="stmt" count="113"/>
-      <line num="749" type="stmt" count="113"/>
-      <line num="750" type="stmt" count="4"/>
-      <line num="751" type="stmt" count="4"/>
-      <line num="753" type="stmt" count="4"/>
-      <line num="754" type="stmt" count="113"/>
-      <line num="755" type="stmt" count="113"/>
-      <line num="756" type="stmt" count="113"/>
-      <line num="757" type="stmt" count="113"/>
+      <line num="710" type="stmt" count="116"/>
+      <line num="711" type="stmt" count="116"/>
+      <line num="713" type="stmt" count="116"/>
+      <line num="715" type="stmt" count="116"/>
+      <line num="716" type="stmt" count="116"/>
+      <line num="717" type="stmt" count="116"/>
+      <line num="720" type="stmt" count="116"/>
+      <line num="721" type="stmt" count="116"/>
+      <line num="723" type="stmt" count="116"/>
+      <line num="724" type="stmt" count="116"/>
+      <line num="725" type="stmt" count="116"/>
+      <line num="726" type="stmt" count="116"/>
+      <line num="727" type="stmt" count="116"/>
+      <line num="728" type="stmt" count="116"/>
+      <line num="730" type="stmt" count="116"/>
+      <line num="731" type="stmt" count="116"/>
+      <line num="733" type="stmt" count="116"/>
+      <line num="736" type="method" name="loadComplexTypeFromChildNode" visibility="private" complexity="10" crap="10" count="116"/>
+      <line num="742" type="stmt" count="116"/>
+      <line num="743" type="stmt" count="116"/>
+      <line num="744" type="stmt" count="116"/>
+      <line num="745" type="stmt" count="116"/>
+      <line num="746" type="stmt" count="116"/>
+      <line num="748" type="stmt" count="116"/>
+      <line num="749" type="stmt" count="116"/>
+      <line num="750" type="stmt" count="6"/>
+      <line num="751" type="stmt" count="6"/>
+      <line num="753" type="stmt" count="6"/>
+      <line num="754" type="stmt" count="116"/>
+      <line num="755" type="stmt" count="116"/>
+      <line num="756" type="stmt" count="116"/>
+      <line num="757" type="stmt" count="116"/>
       <line num="758" type="stmt" count="2"/>
       <line num="759" type="stmt" count="2"/>
-      <line num="760" type="stmt" count="113"/>
+      <line num="760" type="stmt" count="116"/>
       <line num="761" type="stmt" count="3"/>
       <line num="762" type="stmt" count="3"/>
       <line num="764" type="stmt" count="2"/>
-      <line num="768" type="method" name="loadSimpleType" visibility="private" complexity="5" crap="5" count="113"/>
-      <line num="770" type="stmt" count="113"/>
-      <line num="771" type="stmt" count="113"/>
-      <line num="772" type="stmt" count="113"/>
-      <line num="773" type="stmt" count="113"/>
-      <line num="776" type="stmt" count="113"/>
-      <line num="777" type="stmt" count="113"/>
-      <line num="779" type="stmt" count="113"/>
-      <line num="780" type="stmt" count="113"/>
-      <line num="781" type="stmt" count="113"/>
-      <line num="782" type="stmt" count="113"/>
-      <line num="783" type="stmt" count="113"/>
-      <line num="784" type="stmt" count="113"/>
-      <line num="785" type="stmt" count="113"/>
-      <line num="786" type="stmt" count="113"/>
-      <line num="787" type="stmt" count="113"/>
-      <line num="788" type="stmt" count="113"/>
-      <line num="790" type="stmt" count="113"/>
-      <line num="791" type="stmt" count="113"/>
-      <line num="793" type="stmt" count="113"/>
-      <line num="794" type="stmt" count="113"/>
-      <line num="796" type="stmt" count="113"/>
-      <line num="799" type="method" name="loadList" visibility="private" complexity="2" crap="2" count="113"/>
-      <line num="801" type="stmt" count="113"/>
-      <line num="805" type="stmt" count="113"/>
-      <line num="806" type="stmt" count="113"/>
-      <line num="808" type="stmt" count="113"/>
-      <line num="809" type="stmt" count="113"/>
-      <line num="810" type="stmt" count="113"/>
-      <line num="811" type="stmt" count="113"/>
-      <line num="812" type="stmt" count="113"/>
-      <line num="813" type="stmt" count="113"/>
-      <line num="814" type="stmt" count="113"/>
-      <line num="815" type="stmt" count="113"/>
-      <line num="816" type="stmt" count="113"/>
-      <line num="817" type="stmt" count="113"/>
-      <line num="818" type="stmt" count="113"/>
-      <line num="819" type="stmt" count="113"/>
-      <line num="823" type="method" name="findSomeType" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="828" type="stmt" count="113"/>
-      <line num="829" type="stmt" count="113"/>
-      <line num="830" type="stmt" count="113"/>
-      <line num="831" type="stmt" count="113"/>
-      <line num="832" type="stmt" count="113"/>
-      <line num="835" type="method" name="findSomeTypeFromAttribute" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="840" type="stmt" count="113"/>
-      <line num="841" type="stmt" count="113"/>
-      <line num="842" type="stmt" count="113"/>
-      <line num="843" type="stmt" count="113"/>
-      <line num="844" type="stmt" count="113"/>
-      <line num="847" type="method" name="loadUnion" visibility="private" complexity="3" crap="3" count="113"/>
-      <line num="849" type="stmt" count="113"/>
-      <line num="850" type="stmt" count="113"/>
-      <line num="851" type="stmt" count="113"/>
-      <line num="855" type="stmt" count="113"/>
-      <line num="856" type="stmt" count="113"/>
-      <line num="859" type="stmt" count="113"/>
-      <line num="860" type="stmt" count="113"/>
-      <line num="861" type="stmt" count="113"/>
-      <line num="862" type="stmt" count="113"/>
-      <line num="863" type="stmt" count="113"/>
-      <line num="864" type="stmt" count="113"/>
-      <line num="865" type="stmt" count="113"/>
-      <line num="866" type="stmt" count="113"/>
-      <line num="867" type="stmt" count="113"/>
-      <line num="868" type="stmt" count="113"/>
-      <line num="869" type="stmt" count="113"/>
-      <line num="870" type="stmt" count="113"/>
-      <line num="873" type="method" name="fillTypeNode" visibility="private" complexity="9" crap="9" count="113"/>
-      <line num="875" type="stmt" count="113"/>
-      <line num="876" type="stmt" count="113"/>
-      <line num="878" type="stmt" count="113"/>
-      <line num="879" type="stmt" count="113"/>
-      <line num="880" type="stmt" count="113"/>
-      <line num="884" type="stmt" count="113"/>
-      <line num="885" type="stmt" count="113"/>
-      <line num="886" type="stmt" count="113"/>
-      <line num="887" type="stmt" count="113"/>
-      <line num="888" type="stmt" count="113"/>
-      <line num="889" type="stmt" count="113"/>
-      <line num="890" type="stmt" count="113"/>
-      <line num="891" type="stmt" count="113"/>
-      <line num="892" type="stmt" count="113"/>
-      <line num="893" type="stmt" count="113"/>
-      <line num="895" type="stmt" count="113"/>
-      <line num="896" type="stmt" count="113"/>
-      <line num="897" type="stmt" count="113"/>
-      <line num="898" type="stmt" count="113"/>
-      <line num="899" type="stmt" count="113"/>
-      <line num="901" type="stmt" count="113"/>
-      <line num="902" type="stmt" count="113"/>
-      <line num="905" type="method" name="loadExtension" visibility="private" complexity="2" crap="2" count="113"/>
-      <line num="907" type="stmt" count="113"/>
-      <line num="908" type="stmt" count="113"/>
-      <line num="910" type="stmt" count="113"/>
-      <line num="911" type="stmt" count="113"/>
-      <line num="913" type="stmt" count="113"/>
-      <line num="916" type="method" name="findAndSetSomeBase" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="921" type="stmt" count="113"/>
-      <line num="922" type="stmt" count="113"/>
-      <line num="925" type="method" name="loadExtensionChildNodes" visibility="private" complexity="5" crap="5" count="113"/>
-      <line num="929" type="stmt" count="113"/>
-      <line num="930" type="stmt" count="113"/>
-      <line num="931" type="stmt" count="113"/>
-      <line num="932" type="stmt" count="113"/>
-      <line num="933" type="stmt" count="113"/>
-      <line num="934" type="stmt" count="113"/>
-      <line num="935" type="stmt" count="113"/>
-      <line num="936" type="stmt" count="113"/>
-      <line num="937" type="stmt" count="113"/>
-      <line num="939" type="stmt" count="113"/>
-      <line num="941" type="stmt" count="113"/>
-      <line num="942" type="stmt" count="113"/>
-      <line num="943" type="stmt" count="113"/>
-      <line num="946" type="method" name="loadChildAttributesAndAttributeGroups" visibility="private" complexity="3" crap="3" count="113"/>
-      <line num="951" type="stmt" count="113"/>
-      <line num="952" type="stmt" count="113"/>
-      <line num="953" type="stmt" count="113"/>
-      <line num="954" type="stmt" count="113"/>
-      <line num="955" type="stmt" count="113"/>
-      <line num="956" type="stmt" count="113"/>
-      <line num="957" type="stmt" count="113"/>
-      <line num="958" type="stmt" count="113"/>
-      <line num="959" type="stmt" count="113"/>
-      <line num="960" type="stmt" count="113"/>
-      <line num="961" type="stmt" count="113"/>
-      <line num="962" type="stmt" count="113"/>
-      <line num="963" type="stmt" count="113"/>
-      <line num="964" type="stmt" count="113"/>
-      <line num="965" type="stmt" count="113"/>
-      <line num="966" type="stmt" count="113"/>
-      <line num="967" type="stmt" count="113"/>
-      <line num="971" type="method" name="loadRestriction" visibility="private" complexity="2" crap="2" count="113"/>
-      <line num="973" type="stmt" count="113"/>
-      <line num="974" type="stmt" count="113"/>
-      <line num="975" type="stmt" count="113"/>
-      <line num="976" type="stmt" count="113"/>
-      <line num="978" type="stmt" count="113"/>
-      <line num="979" type="stmt" count="113"/>
-      <line num="980" type="stmt" count="113"/>
-      <line num="981" type="stmt" count="113"/>
-      <line num="982" type="stmt" count="113"/>
-      <line num="983" type="stmt" count="113"/>
-      <line num="984" type="stmt" count="113"/>
-      <line num="985" type="stmt" count="113"/>
-      <line num="986" type="stmt" count="113"/>
-      <line num="987" type="stmt" count="113"/>
-      <line num="988" type="stmt" count="113"/>
-      <line num="989" type="stmt" count="113"/>
-      <line num="990" type="stmt" count="113"/>
-      <line num="991" type="stmt" count="113"/>
-      <line num="992" type="stmt" count="113"/>
-      <line num="993" type="stmt" count="113"/>
-      <line num="994" type="stmt" count="113"/>
-      <line num="995" type="stmt" count="113"/>
-      <line num="997" type="stmt" count="113"/>
-      <line num="1000" type="method" name="loadRestrictionChildNodes" visibility="private" complexity="4" crap="4" count="113"/>
-      <line num="1005" type="stmt" count="113"/>
-      <line num="1006" type="stmt" count="113"/>
-      <line num="1007" type="stmt" count="113"/>
-      <line num="1008" type="stmt" count="113"/>
-      <line num="1009" type="stmt" count="113"/>
-      <line num="1012" type="stmt" count="113"/>
-      <line num="1013" type="stmt" count="113"/>
-      <line num="1016" type="stmt" count="113"/>
-      <line num="1017" type="stmt" count="113"/>
-      <line num="1018" type="stmt" count="113"/>
-      <line num="1019" type="stmt" count="113"/>
-      <line num="1020" type="stmt" count="113"/>
-      <line num="1021" type="stmt" count="113"/>
-      <line num="1022" type="stmt" count="113"/>
-      <line num="1023" type="stmt" count="113"/>
-      <line num="1025" type="stmt" count="113"/>
-      <line num="1026" type="stmt" count="113"/>
-      <line num="1032" type="method" name="splitParts" visibility="private" complexity="4" crap="4" count="113"/>
-      <line num="1034" type="stmt" count="113"/>
-      <line num="1035" type="stmt" count="113"/>
-      <line num="1036" type="stmt" count="113"/>
-      <line num="1037" type="stmt" count="113"/>
-      <line num="1041" type="stmt" count="113"/>
-      <line num="1047" type="stmt" count="113"/>
+      <line num="768" type="method" name="loadSimpleType" visibility="private" complexity="5" crap="5" count="116"/>
+      <line num="770" type="stmt" count="116"/>
+      <line num="771" type="stmt" count="116"/>
+      <line num="772" type="stmt" count="116"/>
+      <line num="773" type="stmt" count="116"/>
+      <line num="776" type="stmt" count="116"/>
+      <line num="777" type="stmt" count="116"/>
+      <line num="779" type="stmt" count="116"/>
+      <line num="780" type="stmt" count="116"/>
+      <line num="781" type="stmt" count="116"/>
+      <line num="782" type="stmt" count="116"/>
+      <line num="783" type="stmt" count="116"/>
+      <line num="784" type="stmt" count="116"/>
+      <line num="785" type="stmt" count="116"/>
+      <line num="786" type="stmt" count="116"/>
+      <line num="787" type="stmt" count="116"/>
+      <line num="788" type="stmt" count="116"/>
+      <line num="790" type="stmt" count="116"/>
+      <line num="791" type="stmt" count="116"/>
+      <line num="793" type="stmt" count="116"/>
+      <line num="794" type="stmt" count="116"/>
+      <line num="796" type="stmt" count="116"/>
+      <line num="799" type="method" name="loadList" visibility="private" complexity="2" crap="2" count="116"/>
+      <line num="801" type="stmt" count="116"/>
+      <line num="805" type="stmt" count="116"/>
+      <line num="806" type="stmt" count="116"/>
+      <line num="808" type="stmt" count="116"/>
+      <line num="809" type="stmt" count="116"/>
+      <line num="810" type="stmt" count="116"/>
+      <line num="811" type="stmt" count="116"/>
+      <line num="812" type="stmt" count="116"/>
+      <line num="813" type="stmt" count="116"/>
+      <line num="814" type="stmt" count="116"/>
+      <line num="815" type="stmt" count="116"/>
+      <line num="816" type="stmt" count="116"/>
+      <line num="817" type="stmt" count="116"/>
+      <line num="818" type="stmt" count="116"/>
+      <line num="819" type="stmt" count="116"/>
+      <line num="823" type="method" name="findSomeType" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="828" type="stmt" count="116"/>
+      <line num="829" type="stmt" count="116"/>
+      <line num="830" type="stmt" count="116"/>
+      <line num="831" type="stmt" count="116"/>
+      <line num="832" type="stmt" count="116"/>
+      <line num="835" type="method" name="findSomeTypeFromAttribute" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="840" type="stmt" count="116"/>
+      <line num="841" type="stmt" count="116"/>
+      <line num="842" type="stmt" count="116"/>
+      <line num="843" type="stmt" count="116"/>
+      <line num="844" type="stmt" count="116"/>
+      <line num="847" type="method" name="loadUnion" visibility="private" complexity="3" crap="3" count="116"/>
+      <line num="849" type="stmt" count="116"/>
+      <line num="850" type="stmt" count="116"/>
+      <line num="851" type="stmt" count="116"/>
+      <line num="855" type="stmt" count="116"/>
+      <line num="856" type="stmt" count="116"/>
+      <line num="859" type="stmt" count="116"/>
+      <line num="860" type="stmt" count="116"/>
+      <line num="861" type="stmt" count="116"/>
+      <line num="862" type="stmt" count="116"/>
+      <line num="863" type="stmt" count="116"/>
+      <line num="864" type="stmt" count="116"/>
+      <line num="865" type="stmt" count="116"/>
+      <line num="866" type="stmt" count="116"/>
+      <line num="867" type="stmt" count="116"/>
+      <line num="868" type="stmt" count="116"/>
+      <line num="869" type="stmt" count="116"/>
+      <line num="870" type="stmt" count="116"/>
+      <line num="873" type="method" name="fillTypeNode" visibility="private" complexity="9" crap="9" count="116"/>
+      <line num="875" type="stmt" count="116"/>
+      <line num="876" type="stmt" count="116"/>
+      <line num="878" type="stmt" count="116"/>
+      <line num="879" type="stmt" count="116"/>
+      <line num="880" type="stmt" count="116"/>
+      <line num="884" type="stmt" count="116"/>
+      <line num="885" type="stmt" count="116"/>
+      <line num="886" type="stmt" count="116"/>
+      <line num="887" type="stmt" count="116"/>
+      <line num="888" type="stmt" count="116"/>
+      <line num="889" type="stmt" count="116"/>
+      <line num="890" type="stmt" count="116"/>
+      <line num="891" type="stmt" count="116"/>
+      <line num="892" type="stmt" count="116"/>
+      <line num="893" type="stmt" count="116"/>
+      <line num="895" type="stmt" count="116"/>
+      <line num="896" type="stmt" count="116"/>
+      <line num="897" type="stmt" count="116"/>
+      <line num="898" type="stmt" count="116"/>
+      <line num="899" type="stmt" count="116"/>
+      <line num="901" type="stmt" count="116"/>
+      <line num="902" type="stmt" count="116"/>
+      <line num="905" type="method" name="loadExtension" visibility="private" complexity="2" crap="2" count="116"/>
+      <line num="907" type="stmt" count="116"/>
+      <line num="908" type="stmt" count="116"/>
+      <line num="910" type="stmt" count="116"/>
+      <line num="911" type="stmt" count="116"/>
+      <line num="913" type="stmt" count="116"/>
+      <line num="916" type="method" name="findAndSetSomeBase" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="921" type="stmt" count="116"/>
+      <line num="922" type="stmt" count="116"/>
+      <line num="925" type="method" name="loadExtensionChildNodes" visibility="private" complexity="5" crap="5" count="116"/>
+      <line num="929" type="stmt" count="116"/>
+      <line num="930" type="stmt" count="116"/>
+      <line num="931" type="stmt" count="116"/>
+      <line num="932" type="stmt" count="116"/>
+      <line num="933" type="stmt" count="116"/>
+      <line num="934" type="stmt" count="116"/>
+      <line num="935" type="stmt" count="116"/>
+      <line num="936" type="stmt" count="116"/>
+      <line num="937" type="stmt" count="116"/>
+      <line num="939" type="stmt" count="116"/>
+      <line num="941" type="stmt" count="116"/>
+      <line num="942" type="stmt" count="116"/>
+      <line num="943" type="stmt" count="116"/>
+      <line num="946" type="method" name="loadChildAttributesAndAttributeGroups" visibility="private" complexity="3" crap="3" count="116"/>
+      <line num="951" type="stmt" count="116"/>
+      <line num="952" type="stmt" count="116"/>
+      <line num="953" type="stmt" count="116"/>
+      <line num="954" type="stmt" count="116"/>
+      <line num="955" type="stmt" count="116"/>
+      <line num="956" type="stmt" count="116"/>
+      <line num="957" type="stmt" count="116"/>
+      <line num="958" type="stmt" count="116"/>
+      <line num="959" type="stmt" count="116"/>
+      <line num="960" type="stmt" count="116"/>
+      <line num="961" type="stmt" count="116"/>
+      <line num="962" type="stmt" count="116"/>
+      <line num="963" type="stmt" count="116"/>
+      <line num="964" type="stmt" count="116"/>
+      <line num="965" type="stmt" count="116"/>
+      <line num="966" type="stmt" count="116"/>
+      <line num="967" type="stmt" count="116"/>
+      <line num="971" type="method" name="loadRestriction" visibility="private" complexity="2" crap="2" count="116"/>
+      <line num="973" type="stmt" count="116"/>
+      <line num="974" type="stmt" count="116"/>
+      <line num="975" type="stmt" count="116"/>
+      <line num="976" type="stmt" count="116"/>
+      <line num="978" type="stmt" count="116"/>
+      <line num="979" type="stmt" count="116"/>
+      <line num="980" type="stmt" count="116"/>
+      <line num="981" type="stmt" count="116"/>
+      <line num="982" type="stmt" count="116"/>
+      <line num="983" type="stmt" count="116"/>
+      <line num="984" type="stmt" count="116"/>
+      <line num="985" type="stmt" count="116"/>
+      <line num="986" type="stmt" count="116"/>
+      <line num="987" type="stmt" count="116"/>
+      <line num="988" type="stmt" count="116"/>
+      <line num="989" type="stmt" count="116"/>
+      <line num="990" type="stmt" count="116"/>
+      <line num="991" type="stmt" count="116"/>
+      <line num="992" type="stmt" count="116"/>
+      <line num="993" type="stmt" count="116"/>
+      <line num="994" type="stmt" count="116"/>
+      <line num="995" type="stmt" count="116"/>
+      <line num="997" type="stmt" count="116"/>
+      <line num="1000" type="method" name="loadRestrictionChildNodes" visibility="private" complexity="4" crap="4" count="116"/>
+      <line num="1005" type="stmt" count="116"/>
+      <line num="1006" type="stmt" count="116"/>
+      <line num="1007" type="stmt" count="116"/>
+      <line num="1008" type="stmt" count="116"/>
+      <line num="1009" type="stmt" count="116"/>
+      <line num="1012" type="stmt" count="116"/>
+      <line num="1013" type="stmt" count="116"/>
+      <line num="1016" type="stmt" count="116"/>
+      <line num="1017" type="stmt" count="116"/>
+      <line num="1018" type="stmt" count="116"/>
+      <line num="1019" type="stmt" count="116"/>
+      <line num="1020" type="stmt" count="116"/>
+      <line num="1021" type="stmt" count="116"/>
+      <line num="1022" type="stmt" count="116"/>
+      <line num="1023" type="stmt" count="116"/>
+      <line num="1025" type="stmt" count="116"/>
+      <line num="1026" type="stmt" count="116"/>
+      <line num="1032" type="method" name="splitParts" visibility="private" complexity="4" crap="4" count="116"/>
+      <line num="1034" type="stmt" count="116"/>
+      <line num="1035" type="stmt" count="116"/>
+      <line num="1036" type="stmt" count="116"/>
+      <line num="1037" type="stmt" count="116"/>
+      <line num="1041" type="stmt" count="116"/>
+      <line num="1047" type="stmt" count="116"/>
       <line num="1048" type="stmt" count="1"/>
-      <line num="1051" type="stmt" count="113"/>
-      <line num="1052" type="stmt" count="113"/>
-      <line num="1053" type="stmt" count="113"/>
-      <line num="1054" type="stmt" count="113"/>
-      <line num="1055" type="stmt" count="113"/>
-      <line num="1058" type="method" name="findAttributeItem" visibility="private" complexity="2" crap="2.26" count="113"/>
-      <line num="1060" type="stmt" count="113"/>
-      <line num="1066" type="stmt" count="113"/>
-      <line num="1068" type="stmt" count="113"/>
+      <line num="1051" type="stmt" count="116"/>
+      <line num="1052" type="stmt" count="116"/>
+      <line num="1053" type="stmt" count="116"/>
+      <line num="1054" type="stmt" count="116"/>
+      <line num="1055" type="stmt" count="116"/>
+      <line num="1058" type="method" name="findAttributeItem" visibility="private" complexity="2" crap="2.26" count="116"/>
+      <line num="1060" type="stmt" count="116"/>
+      <line num="1066" type="stmt" count="116"/>
+      <line num="1068" type="stmt" count="116"/>
       <line num="1069" type="stmt" count="0"/>
       <line num="1070" type="stmt" count="0"/>
-      <line num="1074" type="method" name="findAttributeGroup" visibility="private" complexity="2" crap="2.26" count="113"/>
-      <line num="1076" type="stmt" count="113"/>
-      <line num="1082" type="stmt" count="113"/>
-      <line num="1084" type="stmt" count="113"/>
+      <line num="1074" type="method" name="findAttributeGroup" visibility="private" complexity="2" crap="2.26" count="116"/>
+      <line num="1076" type="stmt" count="116"/>
+      <line num="1082" type="stmt" count="116"/>
+      <line num="1084" type="stmt" count="116"/>
       <line num="1085" type="stmt" count="0"/>
       <line num="1086" type="stmt" count="0"/>
-      <line num="1090" type="method" name="findElement" visibility="private" complexity="2" crap="2.50" count="113"/>
-      <line num="1092" type="stmt" count="113"/>
-      <line num="1095" type="stmt" count="113"/>
+      <line num="1090" type="method" name="findElement" visibility="private" complexity="2" crap="2.50" count="116"/>
+      <line num="1092" type="stmt" count="116"/>
+      <line num="1095" type="stmt" count="116"/>
       <line num="1096" type="stmt" count="0"/>
       <line num="1097" type="stmt" count="0"/>
-      <line num="1101" type="method" name="findGroup" visibility="private" complexity="2" crap="2" count="113"/>
-      <line num="1103" type="stmt" count="113"/>
-      <line num="1109" type="stmt" count="113"/>
-      <line num="1111" type="stmt" count="113"/>
+      <line num="1101" type="method" name="findGroup" visibility="private" complexity="2" crap="2" count="116"/>
+      <line num="1103" type="stmt" count="116"/>
+      <line num="1109" type="stmt" count="116"/>
+      <line num="1111" type="stmt" count="116"/>
       <line num="1112" type="stmt" count="1"/>
       <line num="1113" type="stmt" count="1"/>
-      <line num="1117" type="method" name="findType" visibility="private" complexity="4" crap="4.01" count="113"/>
-      <line num="1119" type="stmt" count="113"/>
-      <line num="1121" type="stmt" count="113"/>
-      <line num="1123" type="stmt" count="113"/>
+      <line num="1117" type="method" name="findType" visibility="private" complexity="4" crap="4.01" count="116"/>
+      <line num="1119" type="stmt" count="116"/>
+      <line num="1121" type="stmt" count="116"/>
+      <line num="1123" type="stmt" count="116"/>
       <line num="1124" type="stmt" count="1"/>
       <line num="1125" type="stmt" count="1"/>
-      <line num="1127" type="stmt" count="113"/>
-      <line num="1129" type="stmt" count="113"/>
-      <line num="1130" type="stmt" count="113"/>
-      <line num="1131" type="stmt" count="113"/>
-      <line num="1132" type="stmt" count="113"/>
+      <line num="1127" type="stmt" count="116"/>
+      <line num="1129" type="stmt" count="116"/>
+      <line num="1130" type="stmt" count="116"/>
+      <line num="1131" type="stmt" count="116"/>
+      <line num="1132" type="stmt" count="116"/>
       <line num="1136" type="stmt" count="0"/>
-      <line num="1139" type="method" name="fillItem" visibility="private" complexity="5" crap="5" count="113"/>
-      <line num="1141" type="stmt" count="113"/>
-      <line num="1142" type="stmt" count="113"/>
-      <line num="1148" type="stmt" count="113"/>
-      <line num="1149" type="stmt" count="113"/>
-      <line num="1150" type="stmt" count="113"/>
-      <line num="1151" type="stmt" count="113"/>
-      <line num="1153" type="stmt" count="113"/>
-      <line num="1154" type="stmt" count="113"/>
-      <line num="1155" type="stmt" count="113"/>
-      <line num="1156" type="stmt" count="113"/>
-      <line num="1157" type="stmt" count="113"/>
-      <line num="1158" type="stmt" count="113"/>
-      <line num="1159" type="stmt" count="113"/>
-      <line num="1160" type="stmt" count="113"/>
-      <line num="1161" type="stmt" count="113"/>
-      <line num="1163" type="stmt" count="113"/>
-      <line num="1164" type="stmt" count="113"/>
-      <line num="1165" type="stmt" count="113"/>
-      <line num="1166" type="stmt" count="113"/>
-      <line num="1167" type="stmt" count="113"/>
-      <line num="1168" type="stmt" count="113"/>
-      <line num="1169" type="stmt" count="113"/>
-      <line num="1170" type="stmt" count="113"/>
-      <line num="1172" type="stmt" count="113"/>
-      <line num="1173" type="stmt" count="113"/>
-      <line num="1174" type="stmt" count="113"/>
-      <line num="1175" type="stmt" count="113"/>
-      <line num="1177" type="stmt" count="113"/>
-      <line num="1180" type="method" name="fillItemNonLocalType" visibility="private" complexity="3" crap="3" count="113"/>
-      <line num="1182" type="stmt" count="113"/>
-      <line num="1186" type="stmt" count="113"/>
-      <line num="1188" type="stmt" count="113"/>
-      <line num="1189" type="stmt" count="113"/>
-      <line num="1190" type="stmt" count="113"/>
-      <line num="1195" type="stmt" count="113"/>
-      <line num="1196" type="stmt" count="113"/>
-      <line num="1197" type="stmt" count="113"/>
-      <line num="1198" type="stmt" count="113"/>
-      <line num="1199" type="stmt" count="113"/>
-      <line num="1202" type="stmt" count="113"/>
-      <line num="1205" type="method" name="loadImport" visibility="private" complexity="13" crap="13" count="113"/>
-      <line num="1209" type="stmt" count="113"/>
-      <line num="1210" type="stmt" count="113"/>
-      <line num="1211" type="stmt" count="113"/>
+      <line num="1139" type="method" name="fillItem" visibility="private" complexity="5" crap="5" count="116"/>
+      <line num="1141" type="stmt" count="116"/>
+      <line num="1142" type="stmt" count="116"/>
+      <line num="1148" type="stmt" count="116"/>
+      <line num="1149" type="stmt" count="116"/>
+      <line num="1150" type="stmt" count="116"/>
+      <line num="1151" type="stmt" count="116"/>
+      <line num="1153" type="stmt" count="116"/>
+      <line num="1154" type="stmt" count="116"/>
+      <line num="1155" type="stmt" count="116"/>
+      <line num="1156" type="stmt" count="116"/>
+      <line num="1157" type="stmt" count="116"/>
+      <line num="1158" type="stmt" count="116"/>
+      <line num="1159" type="stmt" count="116"/>
+      <line num="1160" type="stmt" count="116"/>
+      <line num="1161" type="stmt" count="116"/>
+      <line num="1163" type="stmt" count="116"/>
+      <line num="1164" type="stmt" count="116"/>
+      <line num="1165" type="stmt" count="116"/>
+      <line num="1166" type="stmt" count="116"/>
+      <line num="1167" type="stmt" count="116"/>
+      <line num="1168" type="stmt" count="116"/>
+      <line num="1169" type="stmt" count="116"/>
+      <line num="1170" type="stmt" count="116"/>
+      <line num="1172" type="stmt" count="116"/>
+      <line num="1173" type="stmt" count="116"/>
+      <line num="1174" type="stmt" count="116"/>
+      <line num="1175" type="stmt" count="116"/>
+      <line num="1177" type="stmt" count="116"/>
+      <line num="1180" type="method" name="fillItemNonLocalType" visibility="private" complexity="3" crap="3" count="116"/>
+      <line num="1182" type="stmt" count="116"/>
+      <line num="1186" type="stmt" count="116"/>
+      <line num="1188" type="stmt" count="116"/>
+      <line num="1189" type="stmt" count="116"/>
+      <line num="1190" type="stmt" count="116"/>
+      <line num="1195" type="stmt" count="116"/>
+      <line num="1196" type="stmt" count="116"/>
+      <line num="1197" type="stmt" count="116"/>
+      <line num="1198" type="stmt" count="116"/>
+      <line num="1199" type="stmt" count="116"/>
+      <line num="1202" type="stmt" count="116"/>
+      <line num="1205" type="method" name="loadImport" visibility="private" complexity="13" crap="13" count="116"/>
+      <line num="1209" type="stmt" count="116"/>
+      <line num="1210" type="stmt" count="116"/>
+      <line num="1211" type="stmt" count="116"/>
       <line num="1212" type="stmt" count="1"/>
-      <line num="1216" type="stmt" count="113"/>
+      <line num="1216" type="stmt" count="116"/>
       <line num="1217" type="stmt" count="5"/>
       <line num="1218" type="stmt" count="5"/>
       <line num="1219" type="stmt" count="5"/>
       <line num="1220" type="stmt" count="5"/>
       <line num="1223" type="stmt" count="5"/>
-      <line num="1226" type="stmt" count="113"/>
+      <line num="1226" type="stmt" count="116"/>
       <line num="1227" type="stmt" count="1"/>
       <line num="1228" type="stmt" count="1"/>
-      <line num="1232" type="stmt" count="113"/>
-      <line num="1233" type="stmt" count="113"/>
-      <line num="1235" type="stmt" count="113"/>
-      <line num="1236" type="stmt" count="113"/>
-      <line num="1238" type="stmt" count="113"/>
-      <line num="1239" type="stmt" count="113"/>
+      <line num="1232" type="stmt" count="116"/>
+      <line num="1233" type="stmt" count="116"/>
+      <line num="1235" type="stmt" count="116"/>
+      <line num="1236" type="stmt" count="116"/>
+      <line num="1238" type="stmt" count="116"/>
+      <line num="1239" type="stmt" count="116"/>
       <line num="1242" type="stmt" count="3"/>
       <line num="1245" type="method" name="createOrUseSchemaForNs" visibility="private" complexity="2" crap="2" count="3"/>
       <line num="1247" type="stmt" count="3"/>
@@ -1336,35 +1350,35 @@
       <line num="1275" type="stmt" count="3"/>
       <line num="1276" type="stmt" count="3"/>
       <line num="1278" type="stmt" count="3"/>
-      <line num="1286" type="method" name="getGlobalSchema" visibility="public" complexity="6" crap="6" count="113"/>
-      <line num="1288" type="stmt" count="113"/>
-      <line num="1289" type="stmt" count="113"/>
-      <line num="1290" type="stmt" count="113"/>
-      <line num="1294" type="stmt" count="113"/>
-      <line num="1295" type="stmt" count="113"/>
-      <line num="1296" type="stmt" count="113"/>
-      <line num="1297" type="stmt" count="113"/>
-      <line num="1298" type="stmt" count="113"/>
-      <line num="1299" type="stmt" count="113"/>
-      <line num="1300" type="stmt" count="113"/>
-      <line num="1301" type="stmt" count="113"/>
-      <line num="1303" type="stmt" count="113"/>
-      <line num="1304" type="stmt" count="113"/>
-      <line num="1307" type="stmt" count="113"/>
-      <line num="1308" type="stmt" count="113"/>
-      <line num="1310" type="stmt" count="113"/>
-      <line num="1311" type="stmt" count="113"/>
-      <line num="1312" type="stmt" count="113"/>
-      <line num="1313" type="stmt" count="113"/>
-      <line num="1314" type="stmt" count="113"/>
-      <line num="1315" type="stmt" count="113"/>
-      <line num="1316" type="stmt" count="113"/>
-      <line num="1317" type="stmt" count="113"/>
-      <line num="1322" type="stmt" count="113"/>
-      <line num="1323" type="stmt" count="113"/>
-      <line num="1327" type="stmt" count="113"/>
+      <line num="1286" type="method" name="getGlobalSchema" visibility="public" complexity="6" crap="6" count="116"/>
+      <line num="1288" type="stmt" count="116"/>
+      <line num="1289" type="stmt" count="116"/>
+      <line num="1290" type="stmt" count="116"/>
+      <line num="1294" type="stmt" count="116"/>
+      <line num="1295" type="stmt" count="116"/>
+      <line num="1296" type="stmt" count="116"/>
+      <line num="1297" type="stmt" count="116"/>
+      <line num="1298" type="stmt" count="116"/>
+      <line num="1299" type="stmt" count="116"/>
+      <line num="1300" type="stmt" count="116"/>
+      <line num="1301" type="stmt" count="116"/>
+      <line num="1303" type="stmt" count="116"/>
+      <line num="1304" type="stmt" count="116"/>
+      <line num="1307" type="stmt" count="116"/>
+      <line num="1308" type="stmt" count="116"/>
+      <line num="1310" type="stmt" count="116"/>
+      <line num="1311" type="stmt" count="116"/>
+      <line num="1312" type="stmt" count="116"/>
+      <line num="1313" type="stmt" count="116"/>
+      <line num="1314" type="stmt" count="116"/>
+      <line num="1315" type="stmt" count="116"/>
+      <line num="1316" type="stmt" count="116"/>
+      <line num="1317" type="stmt" count="116"/>
+      <line num="1322" type="stmt" count="116"/>
+      <line num="1323" type="stmt" count="116"/>
+      <line num="1327" type="stmt" count="116"/>
       <line num="1328" type="stmt" count="0"/>
-      <line num="1331" type="stmt" count="113"/>
+      <line num="1331" type="stmt" count="116"/>
       <line num="1337" type="method" name="readNodes" visibility="public" complexity="7" crap="7" count="4"/>
       <line num="1339" type="stmt" count="4"/>
       <line num="1340" type="stmt" count="4"/>
@@ -1382,137 +1396,137 @@
       <line num="1361" type="stmt" count="4"/>
       <line num="1362" type="stmt" count="4"/>
       <line num="1365" type="stmt" count="4"/>
-      <line num="1368" type="method" name="readNode" visibility="public" complexity="3" crap="3" count="109"/>
-      <line num="1370" type="stmt" count="109"/>
-      <line num="1371" type="stmt" count="109"/>
-      <line num="1373" type="stmt" count="109"/>
-      <line num="1374" type="stmt" count="108"/>
-      <line num="1377" type="stmt" count="109"/>
-      <line num="1379" type="stmt" count="109"/>
-      <line num="1381" type="stmt" count="109"/>
-      <line num="1382" type="stmt" count="103"/>
-      <line num="1385" type="stmt" count="108"/>
-      <line num="1391" type="method" name="readString" visibility="public" complexity="2" crap="2" count="105"/>
-      <line num="1393" type="stmt" count="105"/>
-      <line num="1394" type="stmt" count="105"/>
-      <line num="1395" type="stmt" count="105"/>
+      <line num="1368" type="method" name="readNode" visibility="public" complexity="3" crap="3" count="112"/>
+      <line num="1370" type="stmt" count="112"/>
+      <line num="1371" type="stmt" count="112"/>
+      <line num="1373" type="stmt" count="112"/>
+      <line num="1374" type="stmt" count="111"/>
+      <line num="1377" type="stmt" count="112"/>
+      <line num="1379" type="stmt" count="112"/>
+      <line num="1381" type="stmt" count="112"/>
+      <line num="1382" type="stmt" count="106"/>
+      <line num="1385" type="stmt" count="111"/>
+      <line num="1391" type="method" name="readString" visibility="public" complexity="2" crap="2" count="108"/>
+      <line num="1393" type="stmt" count="108"/>
+      <line num="1394" type="stmt" count="108"/>
+      <line num="1395" type="stmt" count="108"/>
       <line num="1396" type="stmt" count="1"/>
-      <line num="1398" type="stmt" count="104"/>
-      <line num="1399" type="stmt" count="104"/>
-      <line num="1401" type="stmt" count="104"/>
+      <line num="1398" type="stmt" count="107"/>
+      <line num="1399" type="stmt" count="107"/>
+      <line num="1401" type="stmt" count="107"/>
       <line num="1407" type="method" name="readFile" visibility="public" complexity="1" crap="1" count="5"/>
       <line num="1409" type="stmt" count="5"/>
       <line num="1411" type="stmt" count="4"/>
-      <line num="1417" type="method" name="getDOM" visibility="private" complexity="2" crap="2" count="114"/>
-      <line num="1419" type="stmt" count="114"/>
-      <line num="1420" type="stmt" count="114"/>
-      <line num="1421" type="stmt" count="114"/>
+      <line num="1417" type="method" name="getDOM" visibility="private" complexity="2" crap="2" count="117"/>
+      <line num="1419" type="stmt" count="117"/>
+      <line num="1420" type="stmt" count="117"/>
+      <line num="1421" type="stmt" count="117"/>
       <line num="1422" type="stmt" count="1"/>
       <line num="1423" type="stmt" count="1"/>
-      <line num="1425" type="stmt" count="113"/>
-      <line num="1427" type="stmt" count="113"/>
-      <line num="1430" type="method" name="againstDOMNodeList" visibility="private" complexity="3" crap="3" count="113"/>
-      <line num="1432" type="stmt" count="113"/>
-      <line num="1433" type="stmt" count="113"/>
-      <line num="1437" type="stmt" count="113"/>
-      <line num="1439" type="stmt" count="113"/>
-      <line num="1440" type="stmt" count="113"/>
-      <line num="1445" type="method" name="loadTypeWithCallback" visibility="private" complexity="4" crap="4" count="113"/>
-      <line num="1450" type="stmt" count="113"/>
-      <line num="1452" type="stmt" count="113"/>
-      <line num="1453" type="stmt" count="113"/>
-      <line num="1454" type="stmt" count="113"/>
-      <line num="1455" type="stmt" count="113"/>
-      <line num="1456" type="stmt" count="113"/>
-      <line num="1457" type="stmt" count="113"/>
-      <line num="1458" type="stmt" count="113"/>
-      <line num="1461" type="stmt" count="113"/>
-      <line num="1462" type="stmt" count="113"/>
-      <line num="1466" type="method" name="createElement" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="1468" type="stmt" count="113"/>
-      <line num="1469" type="stmt" count="113"/>
-      <line num="1470" type="stmt" count="113"/>
-      <line num="1471" type="stmt" count="113"/>
-      <line num="1473" type="stmt" count="113"/>
-      <line num="1476" type="method" name="fillElement" visibility="private" complexity="7" crap="7" count="113"/>
-      <line num="1478" type="stmt" count="113"/>
-      <line num="1479" type="stmt" count="113"/>
-      <line num="1480" type="stmt" count="113"/>
-      <line num="1481" type="stmt" count="113"/>
-      <line num="1482" type="stmt" count="113"/>
-      <line num="1484" type="stmt" count="113"/>
-      <line num="1485" type="stmt" count="113"/>
-      <line num="1487" type="stmt" count="113"/>
-      <line num="1488" type="stmt" count="113"/>
-      <line num="1491" type="stmt" count="113"/>
+      <line num="1425" type="stmt" count="116"/>
+      <line num="1427" type="stmt" count="116"/>
+      <line num="1430" type="method" name="againstDOMNodeList" visibility="private" complexity="3" crap="3" count="116"/>
+      <line num="1432" type="stmt" count="116"/>
+      <line num="1433" type="stmt" count="116"/>
+      <line num="1437" type="stmt" count="116"/>
+      <line num="1439" type="stmt" count="116"/>
+      <line num="1440" type="stmt" count="116"/>
+      <line num="1445" type="method" name="loadTypeWithCallback" visibility="private" complexity="4" crap="4" count="116"/>
+      <line num="1450" type="stmt" count="116"/>
+      <line num="1452" type="stmt" count="116"/>
+      <line num="1453" type="stmt" count="116"/>
+      <line num="1454" type="stmt" count="116"/>
+      <line num="1455" type="stmt" count="116"/>
+      <line num="1456" type="stmt" count="116"/>
+      <line num="1457" type="stmt" count="116"/>
+      <line num="1458" type="stmt" count="116"/>
+      <line num="1461" type="stmt" count="116"/>
+      <line num="1462" type="stmt" count="116"/>
+      <line num="1466" type="method" name="createElement" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="1468" type="stmt" count="116"/>
+      <line num="1469" type="stmt" count="116"/>
+      <line num="1470" type="stmt" count="116"/>
+      <line num="1471" type="stmt" count="116"/>
+      <line num="1473" type="stmt" count="116"/>
+      <line num="1476" type="method" name="fillElement" visibility="private" complexity="7" crap="7" count="116"/>
+      <line num="1478" type="stmt" count="116"/>
+      <line num="1479" type="stmt" count="116"/>
+      <line num="1480" type="stmt" count="116"/>
+      <line num="1481" type="stmt" count="116"/>
+      <line num="1482" type="stmt" count="116"/>
+      <line num="1484" type="stmt" count="116"/>
+      <line num="1485" type="stmt" count="116"/>
+      <line num="1487" type="stmt" count="116"/>
+      <line num="1488" type="stmt" count="116"/>
+      <line num="1491" type="stmt" count="116"/>
       <line num="1492" type="stmt" count="4"/>
-      <line num="1495" type="stmt" count="113"/>
-      <line num="1496" type="stmt" count="113"/>
+      <line num="1495" type="stmt" count="116"/>
+      <line num="1496" type="stmt" count="116"/>
       <line num="1497" type="stmt" count="6"/>
-      <line num="1498" type="stmt" count="113"/>
-      <line num="1499" type="stmt" count="113"/>
-      <line num="1501" type="stmt" count="113"/>
-      <line num="1502" type="stmt" count="113"/>
-      <line num="1503" type="stmt" count="113"/>
-      <line num="1504" type="stmt" count="113"/>
-      <line num="1506" type="stmt" count="113"/>
-      <line num="1510" type="stmt" count="113"/>
-      <line num="1513" type="method" name="createAnyElement" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="1515" type="stmt" count="113"/>
-      <line num="1516" type="stmt" count="113"/>
-      <line num="1518" type="stmt" count="113"/>
-      <line num="1521" type="method" name="fillAnyElement" visibility="private" complexity="4" crap="4" count="113"/>
-      <line num="1523" type="stmt" count="113"/>
-      <line num="1524" type="stmt" count="113"/>
-      <line num="1526" type="stmt" count="113"/>
+      <line num="1498" type="stmt" count="116"/>
+      <line num="1499" type="stmt" count="116"/>
+      <line num="1501" type="stmt" count="116"/>
+      <line num="1502" type="stmt" count="116"/>
+      <line num="1503" type="stmt" count="116"/>
+      <line num="1504" type="stmt" count="116"/>
+      <line num="1506" type="stmt" count="116"/>
+      <line num="1510" type="stmt" count="116"/>
+      <line num="1513" type="method" name="createAnyElement" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="1515" type="stmt" count="116"/>
+      <line num="1516" type="stmt" count="116"/>
+      <line num="1518" type="stmt" count="116"/>
+      <line num="1521" type="method" name="fillAnyElement" visibility="private" complexity="4" crap="4" count="116"/>
+      <line num="1523" type="stmt" count="116"/>
+      <line num="1524" type="stmt" count="116"/>
+      <line num="1526" type="stmt" count="116"/>
       <line num="1527" type="stmt" count="2"/>
-      <line num="1530" type="stmt" count="113"/>
+      <line num="1530" type="stmt" count="116"/>
       <line num="1531" type="stmt" count="3"/>
-      <line num="1534" type="stmt" count="113"/>
-      <line num="1535" type="stmt" count="113"/>
-      <line num="1536" type="stmt" count="113"/>
-      <line num="1537" type="stmt" count="113"/>
-      <line num="1540" type="stmt" count="113"/>
-      <line num="1543" type="method" name="addAttributeFromAttributeOrRef" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="1549" type="stmt" count="113"/>
-      <line num="1550" type="stmt" count="113"/>
-      <line num="1551" type="stmt" count="113"/>
-      <line num="1552" type="stmt" count="113"/>
-      <line num="1553" type="stmt" count="113"/>
-      <line num="1555" type="stmt" count="113"/>
-      <line num="1558" type="method" name="findSomethingLikeAttributeGroup" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="1564" type="stmt" count="113"/>
-      <line num="1565" type="stmt" count="113"/>
-      <line num="1568" type="method" name="setLoadedFile" visibility="private" complexity="1" crap="1" count="113"/>
-      <line num="1570" type="stmt" count="113"/>
-      <line num="1573" type="method" name="setLoadedSchemaFromElement" visibility="private" complexity="2" crap="2" count="113"/>
-      <line num="1575" type="stmt" count="113"/>
-      <line num="1576" type="stmt" count="113"/>
-      <line num="1580" type="method" name="setLoadedSchema" visibility="private" complexity="3" crap="3" count="113"/>
-      <line num="1582" type="stmt" count="113"/>
-      <line num="1583" type="stmt" count="113"/>
-      <line num="1585" type="stmt" count="113"/>
-      <line num="1586" type="stmt" count="113"/>
-      <line num="1590" type="method" name="setSchemaThingsFromNode" visibility="private" complexity="3" crap="3.14" count="113"/>
-      <line num="1595" type="stmt" count="113"/>
-      <line num="1597" type="stmt" count="113"/>
-      <line num="1598" type="stmt" count="113"/>
+      <line num="1534" type="stmt" count="116"/>
+      <line num="1535" type="stmt" count="116"/>
+      <line num="1536" type="stmt" count="116"/>
+      <line num="1537" type="stmt" count="116"/>
+      <line num="1540" type="stmt" count="116"/>
+      <line num="1543" type="method" name="addAttributeFromAttributeOrRef" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="1549" type="stmt" count="116"/>
+      <line num="1550" type="stmt" count="116"/>
+      <line num="1551" type="stmt" count="116"/>
+      <line num="1552" type="stmt" count="116"/>
+      <line num="1553" type="stmt" count="116"/>
+      <line num="1555" type="stmt" count="116"/>
+      <line num="1558" type="method" name="findSomethingLikeAttributeGroup" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="1564" type="stmt" count="116"/>
+      <line num="1565" type="stmt" count="116"/>
+      <line num="1568" type="method" name="setLoadedFile" visibility="private" complexity="1" crap="1" count="116"/>
+      <line num="1570" type="stmt" count="116"/>
+      <line num="1573" type="method" name="setLoadedSchemaFromElement" visibility="private" complexity="2" crap="2" count="116"/>
+      <line num="1575" type="stmt" count="116"/>
+      <line num="1576" type="stmt" count="116"/>
+      <line num="1580" type="method" name="setLoadedSchema" visibility="private" complexity="3" crap="3" count="116"/>
+      <line num="1582" type="stmt" count="116"/>
+      <line num="1583" type="stmt" count="116"/>
+      <line num="1585" type="stmt" count="116"/>
+      <line num="1586" type="stmt" count="116"/>
+      <line num="1590" type="method" name="setSchemaThingsFromNode" visibility="private" complexity="3" crap="3.14" count="116"/>
+      <line num="1595" type="stmt" count="116"/>
+      <line num="1597" type="stmt" count="116"/>
+      <line num="1598" type="stmt" count="116"/>
       <line num="1599" type="stmt" count="0"/>
       <line num="1600" type="stmt" count="0"/>
-      <line num="1602" type="stmt" count="113"/>
-      <line num="1603" type="stmt" count="113"/>
-      <line num="1604" type="stmt" count="113"/>
+      <line num="1602" type="stmt" count="116"/>
+      <line num="1603" type="stmt" count="116"/>
+      <line num="1604" type="stmt" count="116"/>
       <metrics loc="1607" ncloc="1502" classes="1" methods="76" coveredmethods="64" conditionals="0" coveredconditionals="0" statements="785" coveredstatements="754" elements="861" coveredelements="818"/>
     </file>
     <file name="/home/runner/work/xsd-reader/xsd-reader/src/Utils/UrlUtils.php">
       <class name="GoetasWebservices\XML\XSDReader\Utils\UrlUtils" namespace="global">
         <metrics complexity="14" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="44" coveredstatements="43" elements="48" coveredelements="46"/>
       </class>
-      <line num="9" type="method" name="resolveRelativeUrl" visibility="public" complexity="5" crap="5" count="122"/>
-      <line num="11" type="stmt" count="122"/>
+      <line num="9" type="method" name="resolveRelativeUrl" visibility="public" complexity="5" crap="5" count="125"/>
+      <line num="11" type="stmt" count="125"/>
       <line num="12" type="stmt" count="2"/>
-      <line num="15" type="stmt" count="121"/>
-      <line num="16" type="stmt" count="113"/>
+      <line num="15" type="stmt" count="124"/>
+      <line num="16" type="stmt" count="116"/>
       <line num="19" type="stmt" count="10"/>
       <line num="20" type="stmt" count="2"/>
       <line num="23" type="stmt" count="10"/>
@@ -1558,6 +1572,6 @@
       <line num="106" type="stmt" count="8"/>
       <metrics loc="109" ncloc="89" classes="1" methods="4" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="44" coveredstatements="43" elements="48" coveredelements="46"/>
     </file>
-    <metrics files="54" loc="3510" ncloc="3225" classes="26" methods="217" coveredmethods="178" conditionals="0" coveredconditionals="0" statements="1058" coveredstatements="1000" elements="1275" coveredelements="1178"/>
+    <metrics files="54" loc="3548" ncloc="3249" classes="27" methods="218" coveredmethods="178" conditionals="0" coveredconditionals="0" statements="1071" coveredstatements="1012" elements="1289" coveredelements="1190"/>
   </project>
 </coverage>

--- a/src/Schema/Element/Choice.php
+++ b/src/Schema/Element/Choice.php
@@ -10,4 +10,42 @@ class Choice extends AbstractNamedGroupItem implements ElementItem, ElementConta
 {
     use ElementContainerTrait;
     use MinMaxTrait;
+
+    /**
+     * A choice selects exactly one of its members per occurrence. When the
+     * choice itself is repeatable, each member can therefore occur any number
+     * of times across the repetitions. Multiplying the occurrences (as is done
+     * for a group reference around a sequence) is unsound here, so repeatable
+     * members are exposed as unbounded lists (maxOccurs unbounded).
+     *
+     * For minOccurs: when the choice has more than one member, every member is
+     * optional (another branch may be selected instead), so minOccurs becomes
+     * 0. A single-member choice degenerates to that one member, so it keeps the
+     * choice's own minOccurs.
+     *
+     * @return ElementItem[]
+     */
+    public function getElements(): array
+    {
+        $max = $this->getMax();
+        if (-1 !== $max && $max <= 1) {
+            return $this->elements;
+        }
+
+        $min = count($this->elements) > 1 ? 0 : $this->getMin();
+
+        $elements = $this->elements;
+        foreach ($elements as $k => $element) {
+            if (!$element instanceof InterfaceSetMinMax) {
+                continue;
+            }
+
+            $clonedElement = clone $element;
+            $clonedElement->setMin($min);
+            $clonedElement->setMax(-1);
+            $elements[$k] = $clonedElement;
+        }
+
+        return $elements;
+    }
 }

--- a/tests/ChoiceTest.php
+++ b/tests/ChoiceTest.php
@@ -196,6 +196,68 @@ class ChoiceTest extends BaseTest
         self::assertCount(3, $choice->getElements());
     }
 
+    public function testRepeatingChoiceExposesMembersAsOptionalUnboundedLists(): void
+    {
+        $schema = $this->reader->readString(
+            '
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                <xs:element name="Languages">
+                    <xs:complexType>
+                        <xs:choice maxOccurs="unbounded">
+                            <xs:element name="german" type="xs:string" />
+                            <xs:element name="english" type="xs:string" />
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
+            </xs:schema>'
+        );
+
+        $choice = $schema->getElements()['Languages']->getType()->getElements()[0];
+        self::assertInstanceOf(Choice::class, $choice);
+        self::assertEquals(1, $choice->getMin());
+        self::assertEquals(-1, $choice->getMax());
+
+        // More than one member: a single occurrence selects exactly one branch,
+        // so every member is optional (minOccurs 0) and - because the choice
+        // repeats - unbounded (maxOccurs -1), regardless of the choice's own min.
+        $members = $choice->getElements();
+        self::assertCount(2, $members);
+        foreach ($members as $member) {
+            self::assertEquals(0, $member->getMin());
+            self::assertEquals(-1, $member->getMax());
+        }
+    }
+
+    public function testRepeatingSingleMemberChoiceKeepsChoiceMinForItsMember(): void
+    {
+        $schema = $this->reader->readString(
+            '
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                <xs:element name="Languages">
+                    <xs:complexType>
+                        <xs:choice maxOccurs="unbounded">
+                            <xs:element name="german" type="xs:string" />
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
+            </xs:schema>'
+        );
+
+        $choice = $schema->getElements()['Languages']->getType()->getElements()[0];
+        self::assertInstanceOf(Choice::class, $choice);
+        self::assertEquals(1, $choice->getMin());
+        self::assertEquals(-1, $choice->getMax());
+
+        // A single-member choice degenerates to that one member: it is always
+        // the selected branch, so it keeps the choice's own minOccurs (1 here)
+        // instead of dropping to 0, while still being an unbounded list.
+        $members = $choice->getElements();
+        self::assertCount(1, $members);
+        self::assertEquals('german', $members[0]->getName());
+        self::assertEquals(1, $members[0]->getMin());
+        self::assertEquals(-1, $members[0]->getMax());
+    }
+
     public function testChoiceNested(): void
     {
         $schema = $this->reader->readString(

--- a/tests/ElementsTest.php
+++ b/tests/ElementsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GoetasWebservices\XML\XSDReader\Tests;
 
+use GoetasWebservices\XML\XSDReader\Schema\Element\Choice;
 use GoetasWebservices\XML\XSDReader\Schema\Element\Element;
 use GoetasWebservices\XML\XSDReader\Schema\Element\ElementDef;
 use GoetasWebservices\XML\XSDReader\Schema\Element\ElementItem;
@@ -261,6 +262,50 @@ class ElementsTest extends BaseTest
         // @todo this is not yet really working
         //        self::assertEquals(2, $myGroupRef->getMin());
         //        self::assertEquals(5, $myGroupRef->getMax());
+    }
+
+    public function testRepeatingGroupRefAroundChoiceMakesMembersOptionalUnboundedLists(): void
+    {
+        $schema = $this->reader->readString(
+            '
+            <xs:schema targetNamespace="http://www.example.com" xmlns:ex="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                <xs:complexType name="myType">
+                    <xs:sequence>
+                        <xs:group minOccurs="0" maxOccurs="unbounded" ref="ex:myGroup" />
+                    </xs:sequence>
+                </xs:complexType>
+
+                <xs:group name="myGroup">
+                    <xs:choice>
+                        <xs:element name="delete" type="xs:string" />
+                        <xs:element name="write" type="xs:string" />
+                    </xs:choice>
+                </xs:group>
+            </xs:schema>');
+
+        $myType = $schema->findType('myType', 'http://www.example.com');
+        self::assertInstanceOf(ComplexType::class, $myType);
+
+        $myGroupRef = $myType->getElements()[0];
+        self::assertInstanceOf(GroupRef::class, $myGroupRef);
+
+        $choice = $myGroupRef->getElements()[0];
+        self::assertInstanceOf(Choice::class, $choice);
+        self::assertEquals(-1, $choice->getMax());
+
+        // The group repeats unbounded, so each choice member can occur any number
+        // of times. Because it is a choice, every member is also optional (one
+        // branch is picked per occurrence) - so min must be 0, not multiplied.
+        $members = $choice->getElements();
+        self::assertCount(2, $members);
+
+        self::assertEquals('delete', $members[0]->getName());
+        self::assertEquals(0, $members[0]->getMin());
+        self::assertEquals(-1, $members[0]->getMax());
+
+        self::assertEquals('write', $members[1]->getName());
+        self::assertEquals(0, $members[1]->getMin());
+        self::assertEquals(-1, $members[1]->getMax());
     }
 
     public function testAnonym(): void


### PR DESCRIPTION
### Problem

A `<group>` referenced with `maxOccurs` greater than 1 (or `unbounded`) around an `<xs:choice>` did not pass that repetition down to the choice members. Each member kept `maxOccurs="1"`, so a consumer could not tell that the elements may repeat.

```xml
<xs:group name="Operation">
  <xs:choice>
    <xs:element name="delete" type="xs:string"/>
    <xs:element name="write" type="xs:string"/>
  </xs:choice>
</xs:group>

<xs:complexType name="Message">
  <xs:sequence>
    <xs:group ref="tns:Operation" minOccurs="0" maxOccurs="unbounded"/>
  </xs:sequence>
</xs:complexType>
```

Before this change, `delete` and `write` were read as `maxOccurs="1"`. After it, both are `minOccurs="0"`, `maxOccurs="-1"` (optional, unbounded).

### Why the old behavior happened

`GroupRef::getElements()` already applies the reference occurrences to its direct children (#91). When the group's direct child is a `<choice>`, that only updates the `Choice` node's own min/max; the choice members are never touched. `SchemaReader` does handle an inline `<choice maxOccurs="...">` at parse time (#88), but a named group is parsed once and shared across every reference to it, so the reference `maxOccurs` is not known at parse time and cannot be written onto the shared definition. The reference occurrences only become known when the reference is expanded, which is `GroupRef::getElements()`.

### The fix

`Choice::getElements()` now applies the choice occurrences to its members when the choice is repeatable, the same way `GroupRef` already does for group references.

### Why `maxOccurs` becomes `-1` instead of a product

This keeps the decision from #88. A choice selects one branch per occurrence, and a member can carry its own `maxOccurs`, so a single integer can no longer describe the member count across repetitions. A member with `maxOccurs="3"` under a choice repeated five times has valid counts that do not reduce to one number. Instead of computing a product that is hard to trust, a repeating choice marks its members as unbounded (`-1`). That is the safe upper bound: it never rejects a document the schema allows.

### Why `minOccurs` becomes `0`, except for a single-member choice

With more than one branch, any single member can be absent because another branch satisfies the occurrence. This holds even when the choice itself is required: `<choice minOccurs="2">` over `a` and `b` can be satisfied with two `b` values, so `a` may appear zero times. The choice `minOccurs` does not transfer to a member, and neither does the member's own `minOccurs`, which only applies when that branch is selected. So a member of a multi-member choice gets `minOccurs="0"`.

A single-member choice is the exception. The one member is the only branch, so it is always selected, and it keeps the choice's own `minOccurs` rather than dropping to 0.

```php
$min = count($this->elements) > 1 ? 0 : $this->getMin();
```

### Scope

Non-repeating choices are unchanged. The change composes with #91: a group reference sets the cloned choice's max, and the choice then applies that to its members when it is expanded.

### Tests

`ChoiceTest` covers a repeating multi-member choice (members become `0 / -1`) and a single-member choice (member keeps the choice's min). `ElementsTest` covers the group-reference-around-a-choice case.
